### PR TITLE
#15 SPDB-720: fault_injection_fs: avoid division by zero in DropRandomUns…

### DIFF
--- a/utilities/fault_injection_fs.cc
+++ b/utilities/fault_injection_fs.cc
@@ -81,9 +81,11 @@ IOStatus FSFileState::DropUnsyncedData() {
 }
 
 IOStatus FSFileState::DropRandomUnsyncedData(Random* rand) {
-  int range = static_cast<int>(buffer_.size());
-  size_t truncated_size = static_cast<size_t>(rand->Uniform(range));
-  buffer_.resize(truncated_size);
+  const int range = static_cast<int>(buffer_.size());
+  if (range > 0) {
+    size_t truncated_size = static_cast<size_t>(rand->Uniform(range));
+    buffer_.resize(truncated_size);
+  }
   return IOStatus::OK();
 }
 


### PR DESCRIPTION
…yncedData()

When there's no data in the buffer, there's nothing to drop anyway, and
providing 0 to the rand->Uniform() function results in a division by zero
error (SIGFPE), so just check and do nothing in that case.