### PR TITLE
#14:optimize memtable switch latency

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1952,7 +1952,7 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   }
   if (s.ok()) {
     SequenceNumber seq = versions_->LastSequence();
-    new_mem = cfd->ConstructNewMemtable(mutable_cf_options, seq);
+    new_mem = cfd->GetSwitchMemtable(seq);
     context->superversion_context.NewSuperVersion();
   }
   ROCKS_LOG_INFO(immutable_db_options_.info_log,

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -69,12 +69,13 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
                    const ImmutableOptions& ioptions,
                    const MutableCFOptions& mutable_cf_options,
                    WriteBufferManager* write_buffer_manager,
-                   SequenceNumber latest_seq, uint32_t column_family_id)
+                   SequenceNumber latest_seq, uint32_t column_family_id,
+                   bool pending)
     : comparator_(cmp),
       moptions_(ioptions, mutable_cf_options),
       refs_(0),
       kArenaBlockSize(OptimizeBlockSize(moptions_.arena_block_size)),
-      mem_tracker_(write_buffer_manager),
+      mem_tracker_(write_buffer_manager, pending),
       arena_(moptions_.arena_block_size,
              (write_buffer_manager != nullptr &&
               (write_buffer_manager->enabled() ||
@@ -97,8 +98,6 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
       flush_completed_(false),
       file_number_(0),
       first_seqno_(0),
-      earliest_seqno_(latest_seq),
-      creation_seq_(latest_seq),
       mem_next_logfile_number_(0),
       min_prep_log_referenced_(0),
       locks_(moptions_.inplace_update_support
@@ -112,6 +111,7 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
       oldest_key_time_(std::numeric_limits<uint64_t>::max()),
       atomic_flush_seqno_(kMaxSequenceNumber),
       approximate_memory_usage_(0) {
+  SetInitialSeq(latest_seq);
   UpdateFlushState();
   // something went wrong if we need to flush before inserting anything
   assert(!ShouldScheduleFlush());
@@ -129,6 +129,17 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
 MemTable::~MemTable() {
   mem_tracker_.FreeMem();
   assert(refs_ == 0);
+}
+
+void MemTable::SetInitialSeq(SequenceNumber sn) {
+  earliest_seqno_ = sn;
+  creation_seq_ = sn;
+}
+
+void MemTable::Activate(SequenceNumber sn) {
+  SetInitialSeq(sn);
+  arena_.Activate();
+
 }
 
 size_t MemTable::ApproximateMemoryUsage() {

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -107,7 +107,8 @@ class MemTable {
                     const ImmutableOptions& ioptions,
                     const MutableCFOptions& mutable_cf_options,
                     WriteBufferManager* write_buffer_manager,
-                    SequenceNumber earliest_seq, uint32_t column_family_id);
+                    SequenceNumber earliest_seq, uint32_t column_family_id,
+                    bool pending = false);
   // No copying allowed
   MemTable(const MemTable&) = delete;
   MemTable& operator=(const MemTable&) = delete;
@@ -402,6 +403,14 @@ class MemTable {
   SequenceNumber GetCreationSeq() const { return creation_seq_; }
 
   void SetCreationSeq(SequenceNumber sn) { creation_seq_ = sn; }
+
+  // Sets the initial sequence number for lazy initialization of the memtable
+  // NOTE: should only be called once before any other operation on the memtable
+  void SetInitialSeq(SequenceNumber sn);
+  // Sets the initial sequence number for lazy initialization of the memtable 
+  // and activate mem_tracker_ if needed
+  // NOTE: should only be called once before any other operation on the memtable
+  void Activate(SequenceNumber sn);
 
   // Returns the next active logfile number when this memtable is about to
   // be flushed to storage

--- a/memory/allocator.h
+++ b/memory/allocator.h
@@ -32,12 +32,15 @@ class Allocator {
 
 class AllocTracker {
  public:
-  explicit AllocTracker(WriteBufferManager* write_buffer_manager);
+  explicit AllocTracker(WriteBufferManager* write_buffer_manager, bool pending = false);
   // No copying allowed
   AllocTracker(const AllocTracker&) = delete;
   void operator=(const AllocTracker&) = delete;
 
   ~AllocTracker();
+
+  // Will be called ONLY on a pending memtable
+  void Activate(size_t bytes);
   void Allocate(size_t bytes);
   // Call when we're finished allocating memory so we can free it from
   // the write buffer's limit.
@@ -46,12 +49,14 @@ class AllocTracker {
   void FreeMem();
 
   bool is_freed() const { return write_buffer_manager_ == nullptr || freed_; }
-
+ private:
+  bool AllocValid(); 
  private:
   WriteBufferManager* write_buffer_manager_;
   std::atomic<size_t> bytes_allocated_;
   bool done_allocating_;
   bool freed_;
+  bool pending_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memory/arena.cc
+++ b/memory/arena.cc
@@ -66,6 +66,12 @@ Arena::Arena(size_t block_size, AllocTracker* tracker, size_t huge_page_size)
   }
 }
 
+void Arena::Activate() {
+  if (tracker_ != nullptr) {
+    tracker_->Activate(kInlineSize);
+  }  
+}
+
 Arena::~Arena() {
   if (tracker_ != nullptr) {
     assert(tracker_->is_freed());

--- a/memory/arena.h
+++ b/memory/arena.h
@@ -42,6 +42,8 @@ class Arena : public Allocator {
                  AllocTracker* tracker = nullptr, size_t huge_page_size = 0);
   ~Arena();
 
+  void Activate();
+
   char* Allocate(size_t bytes) override;
 
   // huge_page_size: if >0, will try to allocate from huage page TLB.

--- a/memory/concurrent_arena.h
+++ b/memory/concurrent_arena.h
@@ -48,6 +48,10 @@ class ConcurrentArena : public Allocator {
                            AllocTracker* tracker = nullptr,
                            size_t huge_page_size = 0);
 
+  void Activate() {
+    arena_.Activate();
+  }                         
+
   char* Allocate(size_t bytes) override {
     return AllocateImpl(bytes, false /*force_arena*/,
                         [this, bytes]() { return arena_.Allocate(bytes); });


### PR DESCRIPTION
With the new speedb memtable, each memtable switch needs to wait
for the allocation and initialization of ~8MiB, which creates
spikes in latency when switching memtables. Add a thread per CF
to allocate new memtables in the background so that they'll be
ready to be used when a switch happens.

Closes #14 