### PR TITLE
#27: customizable_test: fix breakage caused by SPDB-556

### DIFF
--- a/options/customizable_test.cc
+++ b/options/customizable_test.cc
@@ -236,18 +236,20 @@ class SimpleConfigurable : public Configurable {
                     dynamic_unsafe_offsetof(so, so.b), OptionType::kBoolean,
                     OptionVerificationType::kNormal, OptionTypeFlags::kNone});
     simple_option_info.emplace(
-        "unique", OptionTypeInfo::AsCustomUniquePtr<TestCustomizable>(
-                      dynamic_unsafe_offsetof(so, so.cu),
-                      OptionVerificationType::kNormal, OptionTypeFlags::kNone));
+        "unique",
+        OptionTypeInfo::AsCustomUniquePtr<TestCustomizable>(
+            dynamic_unsafe_offsetof(so, so.cu), OptionVerificationType::kNormal,
+            OptionTypeFlags::kAllowNull));
     simple_option_info.emplace(
-        "shared", OptionTypeInfo::AsCustomSharedPtr<TestCustomizable>(
-                      dynamic_unsafe_offsetof(so, so.cs),
-                      OptionVerificationType::kNormal, OptionTypeFlags::kNone));
+        "shared",
+        OptionTypeInfo::AsCustomSharedPtr<TestCustomizable>(
+            dynamic_unsafe_offsetof(so, so.cs), OptionVerificationType::kNormal,
+            OptionTypeFlags::kAllowNull));
     simple_option_info.emplace(
         "pointer",
         OptionTypeInfo::AsCustomRawPtr<TestCustomizable>(
             dynamic_unsafe_offsetof(so, so.cp), OptionVerificationType::kNormal,
-            OptionTypeFlags::kNone));
+            OptionTypeFlags::kAllowNull));
 #endif  // ROCKSDB_LITE
     RegisterOptions(&simple_, &simple_option_info);
   }


### PR DESCRIPTION
When fixing the clang compilation errors (offsetof() being applied
to non standard layout types), the pointer flags were mistakenly set
to `kNone` from `kAllowNone`. This didn't cause an issue with the tests
on 6.22.1, but it does after the rebase on 7.2.2. Add the missing flags
back so that the test passes.