### PR TITLE
mutable_db_options: fix a Clang 14 build error

### DIFF
--- a/options/db_options.h
+++ b/options/db_options.h
@@ -117,8 +117,6 @@ struct MutableDBOptions {
   MutableDBOptions();
   explicit MutableDBOptions(const DBOptions& options);
 
-  MutableDBOptions& operator=(const MutableDBOptions&) = default;
-
   void Dump(Logger* log) const;
 
   int max_background_jobs;


### PR DESCRIPTION
Clang 14 fails to compile with the following error:

```
options/db_options.h:120:21: error: definition of implicit copy constructor for 'MutableDBOptions' is deprecated because it has a user-declared copy assignment operator [-Werror,-Wdeprecated-copy]
  MutableDBOptions& operator=(const MutableDBOptions&) = default;
                    ^
db/compaction/compaction_job.cc:439:7: note: in implicit copy constructor for 'rocksdb::MutableDBOptions' first required here
      mutable_db_options_copy_(mutable_db_options),
      ^
```

Fix it by adding an explicit copy constructor.

**EDIT**: Caused by a change I made that was part of #7. The contents of the PR are changed to simply revert that change.