### PR TITLE
crash_test: add the new memtable as a random choice (#89)

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -310,7 +310,7 @@ simple_default_params = {
     "experimental_mempurge_threshold": lambda: 10.0*random.random(),
     "max_background_compactions": 1,
     "max_bytes_for_level_base": 67108864,
-    "memtablerep": "skip_list",
+    "memtablerep": lambda: random.choice(["skip_list", "speedb.HashSpdRepFactory"]),
     "target_file_size_base": 16777216,
     "target_file_size_multiplier": 1,
     "test_batches_snapshots": 0,
@@ -537,8 +537,9 @@ def finalize_and_sanitize(src_params, counter):
     if dest_params.get("compression_type") != "zstd":
         dest_params["compression_zstd_max_train_bytes"] = 0
     if dest_params.get("allow_concurrent_memtable_write", 1) == 1:
-        # TODO: yuval- add hash_spd memtable
-        dest_params["memtablerep"] = "skip_list"
+        dest_params["memtablerep"] = (
+            random.choice(["skip_list", "speedb.HashSpdRepFactory"]),
+        )
     if dest_params["mmap_read"] == 1:
         dest_params["use_direct_io_for_flush_and_compaction"] = 0
         dest_params["use_direct_reads"] = 0


### PR DESCRIPTION
Currently only the skip list memtable is being tested. Increase
coverage by adding the new Speedb memtable as an option as well.
For now we'll simply choose randomly between the two, without
giving any one of them preference, but we may want to change that
in the future.