### PR TITLE
spdb_memtable: fix an unused parameter issue (#91)

### DIFF
--- a/plugin/speedb/memtable/hash_spd_rep.cc
+++ b/plugin/speedb/memtable/hash_spd_rep.cc
@@ -981,7 +981,7 @@ HashSpdRepFactory::HashSpdRepFactory(size_t bucket_count)
 
 MemTableRep* HashSpdRepFactory::CreateMemTableRep(
     const MemTableRep::KeyComparator& compare, Allocator* allocator,
-    const SliceTransform* /*transform*/, Logger* logger) {
+    const SliceTransform* /*transform*/, Logger* /*logger*/) {
   return new HashLocklessRep(compare, allocator, bucket_count_, 10000);
 }
 


### PR DESCRIPTION
A last minute change before merging #30 breaks builds that configure
`-Werror=unused-parameter` (this is the default for some GCC versions
with the `-Wextra` configuration).

Fix it by not declaring the `logger` argument to the `CreateMemTableRep()`
function.