### PR TITLE
crash_test: fix incorrect passing of the memtablerep argument (#93)

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -537,8 +537,8 @@ def finalize_and_sanitize(src_params, counter):
     if dest_params.get("compression_type") != "zstd":
         dest_params["compression_zstd_max_train_bytes"] = 0
     if dest_params.get("allow_concurrent_memtable_write", 1) == 1:
-        dest_params["memtablerep"] = (
-            random.choice(["skip_list", "speedb.HashSpdRepFactory"]),
+        dest_params["memtablerep"] = random.choice(
+            ["skip_list", "speedb.HashSpdRepFactory"]
         )
     if dest_params["mmap_read"] == 1:
         dest_params["use_direct_io_for_flush_and_compaction"] = 0


### PR DESCRIPTION
As part of #90, I accidentally added a comma at the end of the
line when choosing the memtable reperesntation to use. This is
a tuple construction syntax and was formatted as such by Black,
but unfortunately missed by me and during review.

Fix it by removing the comma so that the argument isn't passed
to db_stress as a Python tuple.