### PR TITLE
crash_test: remove the hash-based memtable from crash test (#98)

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -310,7 +310,7 @@ simple_default_params = {
     "experimental_mempurge_threshold": lambda: 10.0*random.random(),
     "max_background_compactions": 1,
     "max_bytes_for_level_base": 67108864,
-    "memtablerep": lambda: random.choice(["skip_list", "speedb.HashSpdRepFactory"]),
+    "memtablerep": "skip_list",
     "target_file_size_base": 16777216,
     "target_file_size_multiplier": 1,
     "test_batches_snapshots": 0,
@@ -537,9 +537,8 @@ def finalize_and_sanitize(src_params, counter):
     if dest_params.get("compression_type") != "zstd":
         dest_params["compression_zstd_max_train_bytes"] = 0
     if dest_params.get("allow_concurrent_memtable_write", 1) == 1:
-        dest_params["memtablerep"] = random.choice(
-            ["skip_list", "speedb.HashSpdRepFactory"]
-        )
+        # TODO: yuval- add hash_spd memtable
+        dest_params["memtablerep"] = "skip_list"
     if dest_params["mmap_read"] == 1:
         dest_params["use_direct_io_for_flush_and_compaction"] = 0
         dest_params["use_direct_reads"] = 0


### PR DESCRIPTION
The test seems to fail for now, so in order to avoid headaches for devs
working on `main`, let's not test the new memtable until the issues are
fixed. This is not intended as a fix for #98, but rather as a temporary
workaround to allow testing to continue, since no one is supposed to be
using the new memtable yet.