### PR TITLE
ci: add a /var/tmp volume to the QA tests to fix tests failing (#107)

### DIFF
--- a/.github/workflows/qa-tests.yml
+++ b/.github/workflows/qa-tests.yml
@@ -5,58 +5,52 @@ on:
   workflow_call:
 
 env:
-  GTEST_THROW_ON_FAILURE: 0
-  GTEST_OUTPUT: \"xml:/tmp/test-results/\"
-  SKIP_FORMAT_BUCK_CHECKS: 1
   GTEST_COLOR: 1
-  CTEST_OUTPUT_ON_FAILURE: 1
-  CTEST_TEST_TIMEOUT: 300
-  ZLIB_DOWNLOAD_BASE: "https://rocksdb-deps.s3.us-west-2.amazonaws.com/pkgs/zlib"
-  BZIP2_DOWNLOAD_BASE: "https://rocksdb-deps.s3.us-west-2.amazonaws.com/pkgs/bzip2"
-  SNAPPY_DOWNLOAD_BASE: "https://rocksdb-deps.s3.us-west-2.amazonaws.com/pkgs/snappy"
-  LZ4_DOWNLOAD_BASE: "https://rocksdb-deps.s3.us-west-2.amazonaws.com/pkgs/lz4"
-  ZSTD_DOWNLOAD_BASE: "https://rocksdb-deps.s3.us-west-2.amazonaws.com/pkgs/zstd"
+  GTEST_THROW_ON_FAILURE: 0
+  SKIP_FORMAT_BUCK_CHECKS: 1
 
 jobs:
   test:
     runs-on: [self-hosted, ubuntu, asrunner]
     container:
       image: ubuntu:18.04
+      volumes:
+        - /var/tmp:/var/tmp # Needed for env_test's IoctlFriendlyTmpdir
+        - /tmp:/tmp # Needed for running tests on non-overlayfs (can't use /dev/shm because there's not enough RAM on the runner)
     strategy:
       matrix:
         include:
-          - name: unit-test
-            short_test: TMPD=\home\ubuntu make -j2 check
-            long_test: TMPD=\home\ubuntu make -j2 check
+          - name: Unit tests
+            short_test: TMPD="$(mktemp -d /tmp/speedb.XXXX)" make -j$(nproc) check
+            long_test: TMPD="$(mktemp -d /tmp/speedb.XXXX)" make -j$(nproc) check
           - name: black-box
-            short_test: CRASH_TEST_EXT_ARGS="--duration=500" make -j2 blackbox_asan_crash_test
-            long_test: CRASH_TEST_EXT_ARGS="--duration=10000" make -j2 blackbox_asan_crash_test
+            short_test: CRASH_TEST_EXT_ARGS="--duration=500" make -j$(nproc) blackbox_asan_crash_test
+            long_test: CRASH_TEST_EXT_ARGS="--duration=10000" make -j$(nproc) blackbox_asan_crash_test
           - name: white-box
-            short_test: CRASH_TEST_EXT_ARGS="--duration=500" make -j2 whitebox_asan_crash_test
-            long_test: CRASH_TEST_EXT_ARGS="--duration=10000" make -j2 whitebox_asan_crash_test
+            short_test: CRASH_TEST_EXT_ARGS="--duration=500" make -j$(nproc) whitebox_asan_crash_test
+            long_test: CRASH_TEST_EXT_ARGS="--duration=10000" make -j$(nproc) whitebox_asan_crash_test
     
     steps:
       - name: Network hotfix
         run: echo "nameserver 8.8.8.8" > /etc/resolv.conf
     
+      - name: Pre
+        run: |
+          apt update -y
+          apt install -y build-essential clang-format parallel libgflags-dev liblz4-dev libsnappy-dev libzstd-dev python3 python3-pip curl
+
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Pre
-        run: |
-          df -H
-          apt-get update -y && apt-get install -y sudo default-jre default-jdk clang-format parallel moreutils g++ libgflags-dev software-properties-common golang-go gccgo binutils liblz4-dev libsnappy1v5 mlocate sysstat nvme-cli python3 python3-pip nodejs npm liblz4-dev libsnappy-dev libzstd-dev gdb dstat unzip apt-transport-https ca-certificates curl gnupg lsb-release || echo ""
-          sudo mv /usr/bin/parallel /usr/bin/gnu_parallel
-          sudo rm -rf /etc/parallel/config || echo ""
-          
       - name: ${{ matrix.name }}
         run: |
-          echo $GITHUB_REF_NAME
-          if echo $GITHUB_REF_NAME | grep -Eq 'release/'; then
-            echo long
-            make clean && ${{ matrix.long_test }}
-          else
-            echo short
-            make clean && ${{ matrix.short_test }}
-          fi
-          df -H
+          case "$GITHUB_REF_NAME" in
+            release/*)
+              echo "Running long test for release, $(nproc) jobs"
+              make clean && ${{ matrix.long_test }}
+              ;;
+            *)
+              echo "Running short test, $(nproc) jobs"
+              make clean && ${{ matrix.short_test }}
+              ;;
+          esac


### PR DESCRIPTION
The tests that break are `env_test` and `db_test`.

`env_test` fails due to trying to use `FS_IOC_GETVERSION` on an overlayfs,
which doesn't support it. We need to use a host filesystem for this because
only certain filesytsems support this ioctl. For this we add a host bind
volume to /var/tmp which is what the code tries to use.

`db_test` fails for an unknown reason and only in buffered I/O mode, which
might indicate a bug in overlayfs. This is caused by a setting of the `TMPD`
environment variable to the overlayfs mount. Add a mount to the host's /tmp
directory and set `TMPD` to it instead (we can't use the default of /dev/shm
because there's not enough memory available on the runner machines).

While at it, clean up the workflow definition a bit.