### PR TITLE
build: fix the java test target dependencies (#128)

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -437,12 +437,12 @@ java_test: java resolve_test_deps
 	$(AM_V_at) $(JAVAC_CMD) $(JAVAC_ARGS) -cp $(MAIN_CLASSES):$(JAVA_TESTCLASSPATH) -h $(NATIVE_INCLUDE) -d $(TEST_CLASSES)\
 		$(TEST_SOURCES)
 
-test: java java_test run_test
+test: run_test
 
-run_test:
+run_test: java_test
 	$(JAVA_CMD) $(JAVA_ARGS) -Djava.library.path=target -cp "$(MAIN_CLASSES):$(TEST_CLASSES):$(JAVA_TESTCLASSPATH):target/*" org.rocksdb.test.RocksJunitRunner $(ALL_JAVA_TESTS)
 
-run_plugin_test:
+run_plugin_test: java_test
 	$(JAVA_CMD) $(JAVA_ARGS) -Djava.library.path=target -cp "$(MAIN_CLASSES):$(TEST_CLASSES):$(JAVA_TESTCLASSPATH):target/*" org.rocksdb.test.RocksJunitRunner $(ROCKSDB_PLUGIN_JAVA_TESTS)
 
 db_bench: java


### PR DESCRIPTION
The `test` target in the Java Makefile has an incorrect dependency graph
that could cause tests to start executing before the compilation finished
(or even started) when make is invoked in job server mode.

Fix it by specifying target dependencies such that running the tests depends
on having the tests compiled first.