### PR TITLE
bloom_test: fix compilation error with GCC 12 (#136)

### DIFF
--- a/util/bloom_test.cc
+++ b/util/bloom_test.cc
@@ -1009,7 +1009,7 @@ struct RawFilterTester {
   // Points five bytes from the end
   char* metadata_ptr_;
 
-  RawFilterTester() : metadata_ptr_(&*(data_.end() - 5)) {}
+  RawFilterTester() : data_(), metadata_ptr_(&*(data_.end() - 5)) {}
 
   Slice ResetNoFill(uint32_t len_without_metadata, uint32_t num_lines,
                      uint32_t num_probes) {


### PR DESCRIPTION
When compiling bloom_test with GCC 12 it complains about using uninitialised
variables. The error is technically wrong, since only the address is taken,
but since this is a test and there's no performance penalty, initialise
the member to get rid of the error.