### PR TITLE
makefile: avoid setting TEST_TMPDIR unnecessarily (#140)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 make_config.mk
+test_config.mk
 rocksdb.pc
 
 *.a

--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ endif
 endif
 
 export JAVAC_ARGS
-CLEAN_FILES += make_config.mk rocksdb.pc
+CLEAN_FILES += make_config.mk test_config.mk rocksdb.pc
 
 ifeq ($(V), 1)
 $(info $(shell uname -a))

--- a/common.mk
+++ b/common.mk
@@ -14,6 +14,11 @@ endif
 ifeq ($(TEST_TMPDIR),)
 TEST_TMPDIR := $(TMPD)
 endif
+# Avoid setting up the tmp directory on Makefile restarts or when the target
+# isn't a check target
+ifeq ($(MAKE_RESTARTS),)
+ifneq ($(filter %check,$(MAKECMDGOALS)),)
+
 ifeq ($(TEST_TMPDIR),)
 ifeq ($(BASE_TMPDIR),)
 BASE_TMPDIR :=$(TMPDIR)
@@ -28,4 +33,19 @@ BASE_TMPDIR :=/dev/shm
 endif
 TEST_TMPDIR := $(shell mktemp -d "$(BASE_TMPDIR)/rocksdb.XXXX")
 endif
+
+# The `export` line below doesn't work in case Make restarts (due to included
+# makefiles getting remade), so we need to output the directory we created into
+# a temporary config file that will be included by the `include` directive below
+# in case of a restart (we don't want to output it into make_config.mk in order
+# to avoid having the TEST_TMPDIR implicitly set for test that are run through
+# makefiles that include make_config.mk, and because we don't want to change
+# make_config.mk on every run)
+$(shell echo 'TEST_TMPDIR?=$(TEST_TMPDIR)' > test_config.mk)
+
+endif
+endif
+
+-include test_config.mk
+
 export TEST_TMPDIR


### PR DESCRIPTION
The changes in #119 included an upstream commit that moved the TEST_TMPDIR
setting to common.mk and executed it unconditionally.

This is causing pollution of /dev/shm unnecessarily, and also causes the
crash tests and other targets to use /dev/shm when they originally didn't.
On machines with small /dev/shm this leads to the crash tests failing with
an out of space error.

Make the setting of TEST_TMPDIR and the creation of a temporary directory
under it execute only once during a single make invocation and only for
the check target, as it was originally. This requires dealing with make
restarts (due to makefiles getting remade) in the form of adding another
temporary configuration file named test_config.mk