### PR TITLE
Add Plugin Tests to builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1372,6 +1372,7 @@ if(WITH_TESTS)
         utilities/cassandra/cassandra_functional_test.cc
         utilities/cassandra/cassandra_format_test.cc
         utilities/cassandra/cassandra_row_merge_test.cc
+        utilities/cassandra/cassandra_serialize_test.cc
         utilities/checkpoint/checkpoint_test.cc
         utilities/env_timed_test.cc
         utilities/memory/memory_test.cc
@@ -1394,7 +1395,7 @@ if(WITH_TESTS)
         utilities/ttl/ttl_test.cc
         utilities/util_merge_operators_test.cc
         utilities/write_batch_with_index/write_batch_with_index_test.cc
-	${PLUGIN_TESTS}
+        ${PLUGIN_TESTS}
     )
   endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -936,6 +936,16 @@ if( ROCKSDB_PLUGINS )
         ${plugin_root}/${src}
         PROPERTIES COMPILE_FLAGS "${${plugin}_COMPILE_FLAGS}")
     endforeach()
+    get_directory_property(${plugin}_TESTS
+      DIRECTORY ${plugin_root}
+      DEFINITION ${plugin}_TESTS)
+    foreach (test ${${plugin}_TESTS})
+      list(APPEND PLUGIN_TESTS ${plugin_root}/${test})
+      set_source_files_properties(
+        ${plugin_root}/${test}
+        PROPERTIES COMPILE_FLAGS "${${plugin}_COMPILE_FLAGS}")
+    endforeach()
+    
     get_directory_property(${plugin}_INCLUDE_PATHS
       DIRECTORY ${plugin_root}
       DEFINITION ${plugin}_INCLUDE_PATHS)
@@ -1362,7 +1372,6 @@ if(WITH_TESTS)
         utilities/cassandra/cassandra_functional_test.cc
         utilities/cassandra/cassandra_format_test.cc
         utilities/cassandra/cassandra_row_merge_test.cc
-        utilities/cassandra/cassandra_serialize_test.cc
         utilities/checkpoint/checkpoint_test.cc
         utilities/env_timed_test.cc
         utilities/memory/memory_test.cc
@@ -1385,6 +1394,7 @@ if(WITH_TESTS)
         utilities/ttl/ttl_test.cc
         utilities/util_merge_operators_test.cc
         utilities/write_batch_with_index/write_batch_with_index_test.cc
+	${PLUGIN_TESTS}
     )
   endif()
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ STRIPFLAGS = -S -x
 # Transform parallel LOG output into something more readable.
 parallel_log_extract = awk \
   'BEGIN{FS="\t"} { \
-  	t=$$9; sub(/if *\[\[ *"/,"",t); sub(/" =.*/,"",t); sub(/ >.*/,"",t); sub(/.*--gtest_filter=/,"",t); \
-  	printf("%7.3f %s %s\n",4,($$7 == 0 ? "PASS" : "FAIL"),t) \
+     t=$$9; sub(/if *\[\[ *"/,"",t); sub(/" =.*/,"",t); sub(/ >.*/,"",t); sub(/.*--gtest_filter=/,"",t); \
+     printf("%7.3f %s %s\n",4,($$7 == 0 ? "PASS" : "FAIL"),t) \
   }'
 
 # DEBUG_LEVEL can have three values:
@@ -242,6 +242,7 @@ ROCKSDB_PLUGIN_EXTERNS = $(foreach p, $(ROCKSDB_PLUGIN_W_FUNCS), int $($(p)_FUNC
 ROCKSDB_PLUGIN_BUILTINS = $(foreach p, $(ROCKSDB_PLUGIN_W_FUNCS), {\"$(p)\"\, $($(p)_FUNC)}\,)
 ROCKSDB_PLUGIN_LDFLAGS = $(foreach plugin, $(ROCKSDB_PLUGINS), $($(plugin)_LDFLAGS))
 ROCKSDB_PLUGIN_PKGCONFIG_REQUIRES = $(foreach plugin, $(ROCKSDB_PLUGINS), $($(plugin)_PKGCONFIG_REQUIRES))
+ROCKSDB_PLUGIN_TESTS = $(foreach p, $(ROCKSDB_PLUGINS), $(foreach test, $($(p)_TESTS), plugin/$(p)/$(test)))
 
 CXXFLAGS += $(foreach plugin, $(ROCKSDB_PLUGINS), $($(plugin)_CXXFLAGS))
 PLATFORM_LDFLAGS += $(ROCKSDB_PLUGIN_LDFLAGS)
@@ -568,9 +569,9 @@ STRESS_OBJECTS =  $(patsubst %.cc, $(OBJ_DIR)/%.o, $(STRESS_LIB_SOURCES))
 ALL_SOURCES  = $(filter-out util/build_version.cc, $(LIB_SOURCES)) $(TEST_LIB_SOURCES) $(MOCK_LIB_SOURCES) $(GTEST_DIR)/gtest/gtest-all.cc
 ALL_SOURCES += $(TOOL_LIB_SOURCES) $(BENCH_LIB_SOURCES) $(CACHE_BENCH_LIB_SOURCES) $(ANALYZER_LIB_SOURCES) $(STRESS_LIB_SOURCES)
 ALL_SOURCES += $(TEST_MAIN_SOURCES) $(TOOL_MAIN_SOURCES) $(BENCH_MAIN_SOURCES)
-ALL_SOURCES += $(ROCKSDB_PLUGIN_SOURCES)
+ALL_SOURCES += $(ROCKSDB_PLUGIN_SOURCES) $(ROCKSDB_PLUGIN_TESTS)
 
-TESTS = $(patsubst %.cc, %, $(notdir $(TEST_MAIN_SOURCES)))
+TESTS = $(patsubst %.cc, %, $(notdir $(TEST_MAIN_SOURCES) $(ROCKSDB_PLUGIN_TESTS)))
 TESTS += $(patsubst %.c, %, $(notdir $(TEST_MAIN_SOURCES_C)))
 
 # `make check-headers` to very that each header file includes its own
@@ -1282,6 +1283,15 @@ db_sanity_test: $(OBJ_DIR)/tools/db_sanity_test.o $(LIBRARY)
 
 db_repl_stress: $(OBJ_DIR)/tools/db_repl_stress.o $(LIBRARY)
 	$(AM_LINK)
+
+define MakeTestRule
+$(1): $(2) $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_V_CCLD)$(CXX) -L. $(patsubst lib%.a, -l%, $(patsubst lib%.$(PLATFORM_SHARED_EXT), -l%, $$^)) $(EXEC_LDFLAGS) -o $$@ $(LDFLAGS) $(COVERAGEFLAGS)
+endef
+
+# For each PLUGIN test, create a rule to generate the test executable
+$(foreach test, $(ROCKSDB_PLUGIN_TESTS), $(eval $(call MakeTestRule, $(notdir $(patsubst %.cc, %, $(test))), $(patsubst %.cc, $(OBJ_DIR)/%.o, $(test)))))
+
 
 arena_test: $(OBJ_DIR)/memory/arena_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)


### PR DESCRIPTION
Add a xxx_TESTS variable that contains the tests to build for the plugin.  Create rules in CMake and Make to build the corresponding tests.

Note that the same paradigm can be used to build most/all tests, but was left for a second PR (to not complicate the change)