### PR TITLE
memtable_list: avoid rolling back memtable flush on CF drop (#144)

### DIFF
--- a/db/memtable_list.cc
+++ b/db/memtable_list.cc
@@ -638,9 +638,6 @@ void MemTableList::RemoveMemTablesOrRestoreFlags(
   assert(mu);
   mu->AssertHeld();
   assert(to_delete);
-  // we will be changing the version in the next code path,
-  // so we better create a new one, since versions are immutable
-  InstallNewVersion();
 
   // All the later memtables that have the same filenum
   // are part of the same batch. They can be committed now.
@@ -661,6 +658,10 @@ void MemTableList::RemoveMemTablesOrRestoreFlags(
   // read full data as long as column family handle is not deleted, even if
   // the column family is dropped.
   if (s.ok() && !cfd->IsDropped()) {  // commit new state
+    // we will be changing the version in the next code path,
+    // so we better create a new one, since versions are immutable
+    InstallNewVersion();
+
     while (batch_count-- > 0) {
       MemTable* m = current_->memlist_.back();
       if (m->edit_.GetBlobFileAdditions().empty()) {
@@ -701,13 +702,19 @@ void MemTableList::RemoveMemTablesOrRestoreFlags(
                          m->edit_.GetBlobFileAdditions().size(), mem_id);
       }
 
-      m->SetFlushCompleted(false);
-      m->SetFlushInProgress(false);
+      // Do not roll back if the CF has been dropped. There's no point in
+      // setting a pending flush state again since we won't be able to complete
+      // a flush anyway in that state, and we can only drop the memtable after
+      // all handles are destroyed.
+      if (!cfd->IsDropped()) {
+        m->SetFlushCompleted(false);
+        m->SetFlushInProgress(false);
 
-      m->edit_.Clear();
-      num_flush_not_started_++;
-      m->file_number_ = 0;
-      imm_flush_needed.store(true, std::memory_order_release);
+        m->edit_.Clear();
+        num_flush_not_started_++;
+        m->file_number_ = 0;
+        imm_flush_needed.store(true, std::memory_order_release);
+      }
       ++mem_id;
     }
   }


### PR DESCRIPTION
This is a continuation of #126 with changes that were missed there in case
a CF drop was encountered after the flush was completed but before or during
manifest write.

Rolling back on CF drop is meaningless because a flush is not possible
in that state, and the only path forwards is for the memtables to be freed
shortly afterwards, so making them available for flush again is useless
at best.

Additionally, this might be needed for the WriteBufferManager changes in
in the future for triggering flushes based on immutable memory as well,
and rolling back flushes causes the memtable memory to become ready for
flush again for a brief period of time until it is dropped, which might
wrongly affect the WBM decisions.

Finally, the code installs a new version even if no changes are made. This
is unnecessary and as such that part is moved into the version-mutating
code path only.

This PR also adds two regression tests, so we could rely on rollback not
being performed on CF drop.

Test Plan: `make check` with the two added tests, as well as running `make crash_test`.