### PR TITLE
crash_test: clean up DB copies in whitebox and narrow test (#159)

### DIFF
--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -830,6 +830,8 @@ def narrow_crash_main(args, unknown_args):
         time.sleep(2)  # time to stabilize before the next run
 
     shutil.rmtree(dbname, True)
+    for ctr in range(max(0, counter - 2), counter):
+        shutil.rmtree('{}_{}'.format(dbname, ctr), True)
 
 
 # This script runs and kills db_stress multiple times. It checks consistency
@@ -878,7 +880,7 @@ def blackbox_crash_main(args, unknown_args):
     # we need to clean up after ourselves -- only do this on test success
     shutil.rmtree(dbname, True)
     for ctr in range(max(0, counter - 2), counter):
-        shutil.rmtree('{}_{}'.format(dbname, ctr))
+        shutil.rmtree('{}_{}'.format(dbname, ctr), True)
 
 
 # This python script runs db_stress multiple times. Some runs with
@@ -1031,11 +1033,11 @@ def whitebox_crash_main(args, unknown_args):
                 shutil.rmtree(expected_values_dir)
             expected_values_dir = None
             check_mode = (check_mode + 1) % total_check_mode
-            for ctr in range(max(0, counter - 2), counter):
-                shutil.rmtree('{}_{}'.format(dbname, ctr))
-            counter = 0
 
         time.sleep(1)  # time to stabilize after a kill
+
+    for ctr in range(max(0, counter - 2), counter):
+        shutil.rmtree('{}_{}'.format(dbname, ctr), True)
 
 
 def bool_converter(v):
@@ -1085,7 +1087,7 @@ def main():
     args, unknown_args = parser.parse_known_args()
 
     test_tmpdir = os.environ.get(_TEST_DIR_ENV_VAR)
-    if test_tmpdir is not None and not os.path.isdir(test_tmpdir):
+    if test_tmpdir and not os.path.isdir(test_tmpdir):
         print('%s env var is set to a non-existent directory: %s' %
                 (_TEST_DIR_ENV_VAR, test_tmpdir))
         sys.exit(1)


### PR DESCRIPTION
The debugging backup logic in whitebox wasn't cleaning up DB copies on
timeout because the cleanup logic was inside the loop. Move it to the end
of the function to ensure that backups are cleaned up on success.

Also make sure to clean up DB backup copies in the narrow test.