### PR TITLE
build: support ccache and sccache in the Makefile build (#170)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2319,7 +2319,7 @@ rocksdbjavastaticnexusbundlejar: rocksdbjavageneratepom
 # A version of each $(LIBOBJECTS) compiled with -fPIC
 
 jl/%.o: %.cc make_config.mk
-	$(AM_V_CC)mkdir -p $(@D) && $(CXX) $(CXXFLAGS) -fPIC -c $< -o $@ $(COVERAGEFLAGS)
+	$(AM_V_CC)mkdir -p $(@D) && $(CCACHE) $(CXX) $(CXXFLAGS) -fPIC -c $< -o $@ $(COVERAGEFLAGS)
 
 rocksdbjava: $(LIB_OBJECTS)
 ifeq ($(JAVA_HOME),)
@@ -2400,19 +2400,19 @@ IOSVERSION=$(shell defaults read $(PLATFORMSROOT)/iPhoneOS.platform/version CFBu
 else
 ifeq ($(HAVE_POWER8),1)
 $(OBJ_DIR)/util/crc32c_ppc.o: util/crc32c_ppc.c make_config.mk
-	$(AM_V_CC)$(CC) $(CFLAGS) -c $< -o $@
+	$(AM_V_CC)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
 
 $(OBJ_DIR)/util/crc32c_ppc_asm.o: util/crc32c_ppc_asm.S make_config.mk
-	$(AM_V_CC)$(CC) $(CFLAGS) -c $< -o $@
+	$(AM_V_CC)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
 endif
 $(OBJ_DIR)/%.o: %.cc make_config.mk
-	$(AM_V_CC)mkdir -p $(@D) && $(CXX) $(CXXFLAGS) -c $< -o $@ $(COVERAGEFLAGS)
+	$(AM_V_CC)mkdir -p $(@D) && $(CCACHE) $(CXX) $(CXXFLAGS) -c $< -o $@ $(COVERAGEFLAGS)
 
 $(OBJ_DIR)/%.o: %.cpp make_config.mk
-	$(AM_V_CC)mkdir -p $(@D) && $(CXX) $(CXXFLAGS) -c $< -o $@ $(COVERAGEFLAGS)
+	$(AM_V_CC)mkdir -p $(@D) && $(CCACHE) $(CXX) $(CXXFLAGS) -c $< -o $@ $(COVERAGEFLAGS)
 
 $(OBJ_DIR)/%.o: %.c make_config.mk
-	$(AM_V_CC)$(CC) $(CFLAGS) -c $< -o $@
+	$(AM_V_CC)$(CCACHE) $(CC) $(CFLAGS) -c $< -o $@
 endif
 
 # ---------------------------------------------------------------------------

--- a/build_tools/build_detect_platform
+++ b/build_tools/build_detect_platform
@@ -102,6 +102,14 @@ if test -z "$AR"; then
     fi
 fi
 
+if [ "$ROCKSDB_USE_CCACHE" = "1" ]; then
+    if command -v sccache > /dev/null; then
+        CCACHE=sccache
+    elif command -v ccache > /dev/null; then
+        CCACHE=ccache
+    fi
+fi
+
 # Detect OS
 if test -z "$TARGET_OS"; then
     TARGET_OS=`uname -s`
@@ -836,6 +844,7 @@ ROCKSDB_PATCH="$(build_tools/version.sh patch)"
 TMP_OUTPUT="${OUTPUT}.tmp"
 
 {
+    echo "CCACHE=$CCACHE"
     echo "CC=$CC"
     echo "CXX=$CXX"
     echo "AR=$AR"


### PR DESCRIPTION
Add support for detecting and using ccache/sccache to the Makefile build in order to speed up build times as it's done in the CMake configuration.