### PR TITLE
options: fix documentation from #34 purges set to LOW

### DIFF
--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1513,8 +1513,8 @@ struct ReadOptions {
   bool pin_data;
 
   // If true, when PurgeObsoleteFile is called in CleanupIteratorState, we
-  // schedule a background job in the flush job queue and delete obsolete files
-  // in background.
+  // schedule a background job in the compaction job queue and delete obsolete
+  // files in background.
   // Default: false
   bool background_purge_on_iterator_cleanup;
 


### PR DESCRIPTION
since purges are now set from the LOW pri pool,
the bg job scheduled when background_purge_on_iterator_cleanup is true is scheduled in the compaction queue