### PR TITLE
tests: fix breakage caused by the compaction threads value change (#197)

### DIFF
--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -2848,14 +2848,16 @@ TEST_P(DBCompactionTestWithParam, PartialCompactionFailure) {
   options.max_bytes_for_level_multiplier = 2;
   options.compression = kNoCompression;
   options.max_subcompactions = max_subcompactions_;
-  options.max_background_compactions = 1;
 
   env_->SetBackgroundThreads(1, Env::HIGH);
-  env_->SetBackgroundThreads(1, Env::LOW);
   // stop the compaction thread until we simulate the file creation failure.
-  test::SleepingBackgroundTask sleeping_task_low;
-  env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task_low,
-                 Env::Priority::LOW);
+  std::vector<test::SleepingBackgroundTask> sleeping_task_low(
+      std::max(1, env_->GetBackgroundThreads(Env::Priority::LOW)));
+  for (auto& sleeping_task : sleeping_task_low) {
+    env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task,
+                   Env::Priority::LOW);
+    sleeping_task.WaitUntilSleeping();
+  }
 
   options.env = env_;
 
@@ -2885,8 +2887,8 @@ TEST_P(DBCompactionTestWithParam, PartialCompactionFailure) {
 
   // Fail the first file creation.
   env_->non_writable_count_ = 1;
-  sleeping_task_low.WakeUp();
-  sleeping_task_low.WaitUntilDone();
+  sleeping_task_low[0].WakeUp();
+  sleeping_task_low[0].WaitUntilDone();
 
   // Expect compaction to fail here as one file will fail its
   // creation.
@@ -2904,6 +2906,10 @@ TEST_P(DBCompactionTestWithParam, PartialCompactionFailure) {
   }
 
   env_->non_writable_count_ = 0;
+  for (size_t i = 1; i < sleeping_task_low.size(); ++i) {
+    sleeping_task_low[i].WakeUp();
+    sleeping_task_low[i].WaitUntilDone();
+  }
 
   // Make sure RocksDB will not get into corrupted state.
   Reopen(options);

--- a/db/db_range_del_test.cc
+++ b/db/db_range_del_test.cc
@@ -638,6 +638,8 @@ TEST_F(DBRangeDelTest, TableEvictedDuringScan) {
   bbto.cache_index_and_filter_blocks = true;
   bbto.block_cache = NewLRUCache(8 << 20);
   opts.table_factory.reset(NewBlockBasedTableFactory(bbto));
+  opts.max_background_compactions = 1;
+  env_->SetBackgroundThreads(1, Env::Priority::LOW);
   DestroyAndReopen(opts);
 
   // Hold a snapshot so range deletions can't become obsolete during compaction

--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -419,6 +419,7 @@ TEST_F(DeleteFileTest, BackgroundPurgeCopyOptions) {
   for (auto& sleeping_task : sleeping_task_after) {
     env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask, &sleeping_task,
                    Env::Priority::LOW);
+    sleeping_task.WaitUntilSleeping();
   }
 
   // Make sure all background purges are executed


### PR DESCRIPTION
In #194 the default value for background compaction threads was changed to 8 (from 1). This caused some tests to fail, but they were fixed. Alas, the fixes seems to not be complete, as under stress some tests still fail.

Make it so the tests are truly fixed now. This can be checked by running them in a loop with the machine overloaded:

```
$ while ./db_compaction_test --gtest_filter=DBCompactionTestWithParam/DBCompactionTestWithParam.PartialCompactionFailure/1; do sleep 1; done
```

And

```
$ while ./deletefile_test --gtest_filter=DeleteFileTest.BackgroundPurgeCopyOptions; do sleep 1; done
```