### PR TITLE
paired_filter: fix copyright and licence headers (#199)

### DIFF
--- a/plugin/speedb/paired_filter/speedb_db_bloom_filter_test.cc
+++ b/plugin/speedb/paired_filter/speedb_db_bloom_filter_test.cc
@@ -1,11 +1,16 @@
-//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
-//  This source code is licensed under both the GPLv2 (found in the
-//  COPYING file in the root directory) and Apache 2.0 License
-//  (found in the LICENSE.Apache file in the root directory).
+// Copyright (C) 2022 Speedb Ltd. All rights reserved.
 //
-// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file. See the AUTHORS file for names of contributors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <cstring>
 #include <iomanip>

--- a/plugin/speedb/paired_filter/speedb_paired_bloom.cc
+++ b/plugin/speedb/paired_filter/speedb_paired_bloom.cc
@@ -1,4 +1,16 @@
-// TODO: ADD Speedb's Copyright Notice !!!!!
+// Copyright (C) 2022 Speedb Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "plugin/speedb/paired_filter/speedb_paired_bloom.h"
 

--- a/plugin/speedb/paired_filter/speedb_paired_bloom.h
+++ b/plugin/speedb/paired_filter/speedb_paired_bloom.h
@@ -1,4 +1,16 @@
-// TODO: ADD Speedb's Copyright Notice !!!!!
+// Copyright (C) 2022 Speedb Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 #include "rocksdb/filter_policy.h"

--- a/plugin/speedb/paired_filter/speedb_paired_bloom_internal.cc
+++ b/plugin/speedb/paired_filter/speedb_paired_bloom_internal.cc
@@ -1,4 +1,16 @@
-// TODO: ADD Speedb's Copyright Notice !!!!!
+// Copyright (C) 2022 Speedb Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "plugin/speedb/paired_filter/speedb_paired_bloom_internal.h"
 

--- a/plugin/speedb/paired_filter/speedb_paired_bloom_internal.h
+++ b/plugin/speedb/paired_filter/speedb_paired_bloom_internal.h
@@ -1,3 +1,17 @@
+// Copyright (C) 2022 Speedb Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <functional>

--- a/plugin/speedb/speedb_customizable_test.cc
+++ b/plugin/speedb/speedb_customizable_test.cc
@@ -1,4 +1,16 @@
-// TODO: ADD Speedb's Copyright Notice !!!!!
+// Copyright (C) 2022 Speedb Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include <cctype>
 #include <cinttypes>


### PR DESCRIPTION
The paired Bloom filter files are either missing a copyright notice and licence header, or contain the wrong one. Fix that in order to adhere to the contribution guidelines.