### PR TITLE
deletefile_test: fix breakage caused by the compaction threads change

### DIFF
--- a/db/deletefile_test.cc
+++ b/db/deletefile_test.cc
@@ -351,6 +351,16 @@ TEST_F(DeleteFileTest, BackgroundPurgeCFDropTest) {
     TEST_SYNC_POINT("DeleteFileTest::BackgroundPurgeCFDropTest:1");
 
     // Execute background purges.
+    sleeping_task_after[0].WakeUp();
+    sleeping_task_after[0].WaitUntilDone();
+
+    // Schedule a sleeping task in order to ensure background purge completed
+    sleeping_task_after[0].Reset();
+    env_->Schedule(&test::SleepingBackgroundTask::DoSleepTask,
+                   &sleeping_task_after[0], Env::Priority::LOW);
+    sleeping_task_after[0].WaitUntilSleeping();
+
+    // Release all sleeping tasks
     for (auto& sleeping_task : sleeping_task_after) {
       sleeping_task.WakeUp();
       sleeping_task.WaitUntilDone();


### PR DESCRIPTION
In #194 the default value for background compaction threads was changed to 8 (from 1). This caused some tests to fail and fixes were implemented as part of #197. Alas, it seems that the fixes weren't complete, as under stress a test still fail.

Make it so the test is truly fixed now. This can be verified by running them in a loop with the machine overloaded:

```
$ while ./deletefile_test --gtest_filter=DeleteFileTest.BackgroundPurgeCFDropTest; do sleep 1; done
```