### PR TITLE
docs: fix instructions for building Speedb in README.md and INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,9 +11,9 @@ depend on newer gcc/clang with C++17 support (GCC >= 7, Clang >= 5).
 There are few options when compiling Speedb:
 
 -   [recommended] `make static_lib` will compile the Speedb static library
-    (`librocksdb.a`) in release mode.
+    (`libspeedb.a`) in release mode.
 
--   `make shared_lib` will compile the Speedb shared library (`librocksdb.so`)
+-   `make shared_lib` will compile the Speedb shared library (`libspeedb.so`)
     in release mode.
 
 -   `make check` will compile and run all the unit tests. `make check` will

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Release:
 This will build the static library. If you want to build the dynamic library,
 use:
 
-    make rocksdb-shared
+    make speedb-shared
 
 If you want `make` to increase the number of cores used for building, simply use
 the `-j` option.


### PR DESCRIPTION
Both were incorrectly referencing the old artefact names before the changes in #66.