### PR TITLE
Add RefreshOptions method to support live config changes

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1155,6 +1155,7 @@ void DBImpl::RefreshOptions() {
   }
   TEST_SYNC_POINT("DBImpl::RefreshOptions::Start");
   Status s = fs_->FileExists(new_options_file, IOOptions(), nullptr);
+  TEST_SYNC_POINT_CALLBACK("DBImpl::RefreshOptions::FileExists", &s);
   if (!s.ok()) {
     return;
   }
@@ -1167,12 +1168,14 @@ void DBImpl::RefreshOptions() {
   cfg_opts.mutable_options_only = true;
   RocksDBOptionsParser op;
   s = op.Parse(cfg_opts, new_options_file, fs_.get());
+  TEST_SYNC_POINT_CALLBACK("DBImpl::RefreshOptions::Parse", &s);
   if (!s.ok()) {
     ROCKS_LOG_WARN(immutable_db_options_.info_log,
                    "Failed to parse Options file (%s): %s\n",
                    new_options_file.c_str(), s.ToString().c_str());
   } else if (!op.db_opt_map()->empty()) {
     s = SetDBOptions(*(op.db_opt_map()));
+    TEST_SYNC_POINT_CALLBACK("DBImpl::RefreshOptions::SetDBOptions", &s);
     if (!s.ok()) {
       ROCKS_LOG_WARN(immutable_db_options_.info_log,
                      "Failed to refresh DBOptions, Aborting: %s\n",
@@ -1191,6 +1194,7 @@ void DBImpl::RefreshOptions() {
                          cf_name.c_str());
         } else if (!cfd->IsDropped()) {
           s = SetCFOptionsImpl(cfd, cf_opt_map);
+          TEST_SYNC_POINT_CALLBACK("DBImpl::RefreshOptions::SetCFOptions", &s);
           if (!s.ok()) {
             ROCKS_LOG_WARN(immutable_db_options_.info_log,
                            "Failed to refresh CFOptions for CF %s: %s\n",
@@ -1202,9 +1206,11 @@ void DBImpl::RefreshOptions() {
     }
   }
   s = fs_->DeleteFile(new_options_file, IOOptions(), nullptr);
+  TEST_SYNC_POINT_CALLBACK("DBImpl::RefreshOptions::DeleteFile", &s);
   ROCKS_LOG_INFO(immutable_db_options_.info_log,
                  "RefreshOptions Complete, deleting options file %s: %s\n",
                  new_options_file.c_str(), s.ToString().c_str());
+  TEST_SYNC_POINT("DBImpl::RefreshOptions::Complete");
 }
 #endif  // ROCKSDB_LITE
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -276,6 +276,8 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
   periodic_task_functions_.emplace(
       PeriodicTaskType::kRecordSeqnoTime,
       [this]() { this->RecordSeqnoToTimeMapping(); });
+  periodic_task_functions_.emplace(PeriodicTaskType::kRefreshOptions,
+                                   [this]() { this->RefreshOptions(); });
 #endif  // ROCKSDB_LITE
 
   versions_.reset(new VersionSet(dbname_, &immutable_db_options_, file_options_,
@@ -829,6 +831,15 @@ Status DBImpl::StartPeriodicTaskScheduler() {
       return s;
     }
   }
+  if (mutable_db_options_.refresh_options_sec > 0) {
+    Status s = periodic_task_scheduler_.Register(
+        PeriodicTaskType::kRefreshOptions,
+        periodic_task_functions_.at(PeriodicTaskType::kRefreshOptions),
+        mutable_db_options_.refresh_options_sec);
+    if (!s.ok()) {
+      return s;
+    }
+  }
 
   Status s = periodic_task_scheduler_.Register(
       PeriodicTaskType::kFlushInfoLog,
@@ -1127,6 +1138,76 @@ void DBImpl::FlushInfoLog() {
   LogFlush(immutable_db_options_.info_log);
 }
 
+#ifndef ROCKSDB_LITE
+// Periodically checks to see if the new options should be loaded into the
+// process. log.
+void DBImpl::RefreshOptions() {
+  if (shutdown_initiated_) {
+    return;
+  }
+  std::string new_options_file = mutable_db_options_.refresh_options_file;
+  if (new_options_file.empty()) {
+    new_options_file = "Options.new";
+  }
+  if (new_options_file[0] != kFilePathSeparator) {
+    new_options_file = NormalizePath(immutable_db_options_.db_paths[0].path +
+                                     kFilePathSeparator + new_options_file);
+  }
+  TEST_SYNC_POINT("DBImpl::RefreshOptions::Start");
+  Status s = fs_->FileExists(new_options_file, IOOptions(), nullptr);
+  if (!s.ok()) {
+    return;
+  }
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "Refreshing Options from file: %s\n",
+                 new_options_file.c_str());
+
+  ConfigOptions cfg_opts;
+  cfg_opts.ignore_unknown_options = true;
+  cfg_opts.mutable_options_only = true;
+  RocksDBOptionsParser op;
+  s = op.Parse(cfg_opts, new_options_file, fs_.get());
+  if (!s.ok()) {
+    ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                   "Failed to parse Options file (%s): %s\n",
+                   new_options_file.c_str(), s.ToString().c_str());
+  } else if (!op.db_opt_map()->empty()) {
+    s = SetDBOptions(*(op.db_opt_map()));
+    if (!s.ok()) {
+      ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                     "Failed to refresh DBOptions, Aborting: %s\n",
+                     s.ToString().c_str());
+    }
+  }
+  if (s.ok()) {
+    int idx = 0;
+    for (const auto& cf_opt_map : *(op.cf_opt_maps())) {
+      if (!cf_opt_map.empty()) {
+        const auto& cf_name = (*op.cf_names())[idx];
+        auto cfd = versions_->GetColumnFamilySet()->GetColumnFamily(cf_name);
+        if (cfd == nullptr) {
+          ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                         "RefreshOptions failed locating CF: %s\n",
+                         cf_name.c_str());
+        } else if (!cfd->IsDropped()) {
+          s = SetCFOptionsImpl(cfd, cf_opt_map);
+          if (!s.ok()) {
+            ROCKS_LOG_WARN(immutable_db_options_.info_log,
+                           "Failed to refresh CFOptions for CF %s: %s\n",
+                           cf_name.c_str(), s.ToString().c_str());
+          }
+        }
+      }
+      idx++;
+    }
+  }
+  s = fs_->DeleteFile(new_options_file, IOOptions(), nullptr);
+  ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                 "RefreshOptions Complete, deleting options file %s: %s\n",
+                 new_options_file.c_str(), s.ToString().c_str());
+}
+#endif  // ROCKSDB_LITE
+
 Status DBImpl::TablesRangeTombstoneSummary(ColumnFamilyHandle* column_family,
                                            int max_entries_to_print,
                                            std::string* out_str) {
@@ -1178,7 +1259,14 @@ Status DBImpl::SetOptions(
                    cfd->GetName().c_str());
     return Status::InvalidArgument("empty input");
   }
+  return SetCFOptionsImpl(cfd, options_map);
+#endif  // ROCKSDB_LITE
+}
 
+#ifndef ROCKSDB_LITE
+Status DBImpl::SetCFOptionsImpl(
+    ColumnFamilyData* cfd,
+    const std::unordered_map<std::string, std::string>& options_map) {
   MutableCFOptions new_options;
   Status s;
   Status persist_options_status;
@@ -1227,8 +1315,8 @@ Status DBImpl::SetOptions(
   }
   LogFlush(immutable_db_options_.info_log);
   return s;
-#endif  // ROCKSDB_LITE
 }
+#endif  // ROCKSDB_LITE
 
 Status DBImpl::SetDBOptions(
     const std::unordered_map<std::string, std::string>& options_map) {
@@ -1336,6 +1424,18 @@ Status DBImpl::SetDBOptions(
               new_options.stats_persist_period_sec);
         }
       }
+      if (s.ok()) {
+        if (new_options.refresh_options_sec == 0) {
+          s = periodic_task_scheduler_.Unregister(
+              PeriodicTaskType::kRefreshOptions);
+        } else {
+          s = periodic_task_scheduler_.Register(
+              PeriodicTaskType::kRefreshOptions,
+              periodic_task_functions_.at(PeriodicTaskType::kRefreshOptions),
+              new_options.refresh_options_sec);
+        }
+      }
+
       mutex_.Lock();
       if (!s.ok()) {
         return s;

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -1183,6 +1183,11 @@ class DBImpl : public DB {
   // record current sequence number to time mapping
   void RecordSeqnoToTimeMapping();
 
+#ifndef ROCKSDB_LITE
+  // Checks if the options should be updated
+  void RefreshOptions();
+#endif  // ROCKSDB_LITE
+
   // Interface to block and signal the DB in case of stalling writes by
   // WriteBufferManager. Each DBImpl object contains ptr to WBMStallInterface.
   // When DB needs to be blocked or signalled by WriteBufferManager,
@@ -1774,7 +1779,11 @@ class DBImpl : public DB {
                                 ColumnFamilyHandle** handle);
 
   Status DropColumnFamilyImpl(ColumnFamilyHandle* column_family);
-
+#ifndef ROCKSDB_LITE
+  Status SetCFOptionsImpl(
+      ColumnFamilyData* cfd,
+      const std::unordered_map<std::string, std::string>& options_map);
+#endif  // ROCKSDB_LITE
   // Delete any unneeded files and stale in-memory entries.
   void DeleteObsoleteFiles();
   // Delete obsolete files and log status and information of file deletion

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1380,6 +1380,17 @@ TEST_F(DBOptionsTest, RefreshOptionsBadFile) {
                        "[CFOptions \"unknown\"]\n",
                        false));
   ASSERT_NOK(WaitForOptionsUpdate(fs, options.refresh_options_file));
+
+  // Test what happens if the refresh_options_file is a directory, not a file
+  bool exists = false;
+  SyncPoint::GetInstance()->SetCallBack("DBImpl::RefreshOptions::FileExists",
+                                        [&](void* /*arg*/) { exists = true; });
+
+  ASSERT_OK(fs->CreateDir(options.refresh_options_file, IOOptions(), nullptr));
+  TEST_SYNC_POINT("DBOptionsTest::WaitForUpdates");
+  ASSERT_TRUE(exists);
+  ASSERT_OK(fs->FileExists(options.refresh_options_file, IOOptions(), nullptr));
+  ASSERT_OK(fs->DeleteDir(options.refresh_options_file, IOOptions(), nullptr));
 }
 
 TEST_F(DBOptionsTest, RefreshOptionsUnknown) {

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1160,7 +1160,7 @@ TEST_F(DBOptionsTest, ChangeCompression) {
 }
 
 namespace {
-Status WaitForOptionsUpdate(const std::shared_ptr<FileSystem>& fs,
+IOStatus WaitForOptionsUpdate(const std::shared_ptr<FileSystem>& fs,
                             const std::string& options_file) {
   TEST_SYNC_POINT("DBOptionsTest::WaitForUpdates");
   auto s = fs->FileExists(options_file, IOOptions(), nullptr);

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1161,7 +1161,7 @@ TEST_F(DBOptionsTest, ChangeCompression) {
 
 namespace {
 IOStatus WaitForOptionsUpdate(const std::shared_ptr<FileSystem>& fs,
-                            const std::string& options_file) {
+                              const std::string& options_file) {
   TEST_SYNC_POINT("DBOptionsTest::WaitForUpdates");
   auto s = fs->FileExists(options_file, IOOptions(), nullptr);
   SyncPoint::GetInstance()->LoadDependency(

--- a/db/periodic_task_scheduler.cc
+++ b/db/periodic_task_scheduler.cc
@@ -27,6 +27,7 @@ static const std::map<PeriodicTaskType, uint64_t> kDefaultPeriodSeconds = {
     {PeriodicTaskType::kPersistStats, kInvalidPeriodSec},
     {PeriodicTaskType::kFlushInfoLog, 10},
     {PeriodicTaskType::kRecordSeqnoTime, kInvalidPeriodSec},
+    {PeriodicTaskType::kRefreshOptions, kInvalidPeriodSec},
 };
 
 static const std::map<PeriodicTaskType, std::string> kPeriodicTaskTypeNames = {
@@ -34,6 +35,7 @@ static const std::map<PeriodicTaskType, std::string> kPeriodicTaskTypeNames = {
     {PeriodicTaskType::kPersistStats, "pst_st"},
     {PeriodicTaskType::kFlushInfoLog, "flush_info_log"},
     {PeriodicTaskType::kRecordSeqnoTime, "record_seq_time"},
+    {PeriodicTaskType::kRefreshOptions, "refresh_options"},
 };
 
 Status PeriodicTaskScheduler::Register(PeriodicTaskType task_type,

--- a/db/periodic_task_scheduler.h
+++ b/db/periodic_task_scheduler.h
@@ -23,6 +23,7 @@ enum class PeriodicTaskType : uint8_t {
   kPersistStats,
   kFlushInfoLog,
   kRecordSeqnoTime,
+  kRefreshOptions,
   kMax,
 };
 

--- a/db/periodic_task_scheduler_test.cc
+++ b/db/periodic_task_scheduler_test.cc
@@ -42,6 +42,7 @@ TEST_F(PeriodicTaskSchedulerTest, Basic) {
   Options options;
   options.stats_dump_period_sec = kPeriodSec;
   options.stats_persist_period_sec = kPeriodSec;
+  options.refresh_options_sec = 0;
   options.create_if_missing = true;
   options.env = mock_env_.get();
 
@@ -130,6 +131,7 @@ TEST_F(PeriodicTaskSchedulerTest, MultiInstances) {
   Options options;
   options.stats_dump_period_sec = kPeriodSec;
   options.stats_persist_period_sec = kPeriodSec;
+  options.refresh_options_sec = 0;
   options.create_if_missing = true;
   options.env = mock_env_.get();
 

--- a/db_stress_tool/db_stress_common.h
+++ b/db_stress_tool/db_stress_common.h
@@ -302,6 +302,8 @@ DECLARE_bool(two_write_queues);
 DECLARE_bool(use_only_the_last_commit_time_batch_for_recovery);
 DECLARE_uint64(wp_snapshot_cache_bits);
 DECLARE_uint64(wp_commit_cache_bits);
+DECLARE_int32(refresh_options_sec);
+DECLARE_string(refresh_options_file);
 #endif  // !ROCKSDB_LITE
 
 DECLARE_bool(adaptive_readahead);

--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -1010,6 +1010,12 @@ DEFINE_uint64(
 DEFINE_uint64(wp_commit_cache_bits, 23ull,
               "Number of bits to represent write-prepared transaction db's "
               "commit cache. Default: 23 (8M entries)");
+DEFINE_int32(
+    refresh_options_sec, 0,
+    "Frequency (in secs) to look for a new options file (off by default)");
+DEFINE_string(refresh_options_file, "",
+              "File in which to look for new options");
+
 #endif  // !ROCKSDB_LITE
 
 DEFINE_bool(adaptive_readahead, false,

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3126,6 +3126,10 @@ void InitializeOptionsFromFlags(
       FLAGS_verify_sst_unique_id_in_manifest;
   options.memtable_protection_bytes_per_key =
       FLAGS_memtable_protection_bytes_per_key;
+#ifndef ROCKSDB_LITE
+  options.refresh_options_sec = FLAGS_refresh_options_sec;
+  options.refresh_options_file = FLAGS_refresh_options_file;
+#endif  // ROCKSDB_LITE
 
   // Integrated BlobDB
   options.enable_blob_files = FLAGS_enable_blob_files;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1394,6 +1394,13 @@ struct DBOptions {
   // of the contract leads to undefined behaviors with high possibility of data
   // inconsistency, e.g. deleted old data become visible again, etc.
   bool enforce_single_del_contracts = true;
+
+  // If non-zero, a task will be started to check for a new
+  // "refresh_options_file" If found, the refresh task will update the mutable
+  // options from the settings in this file
+  // Not supported in ROCKSDB_LITE mode!
+  unsigned int refresh_options_sec = 0;
+  std::string refresh_options_file;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1398,8 +1398,9 @@ struct DBOptions {
   // If non-zero, a task will be started to check for a new
   // "refresh_options_file" If found, the refresh task will update the mutable
   // options from the settings in this file
+  // Defaults to check once per hour.  Set to 0 to disable the task.
   // Not supported in ROCKSDB_LITE mode!
-  unsigned int refresh_options_sec = 0;
+  unsigned int refresh_options_sec = 60 * 60;
   std::string refresh_options_file;
 };
 

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -102,6 +102,14 @@ static std::unordered_map<std::string, OptionTypeInfo>
          {offsetof(struct MutableDBOptions, stats_persist_period_sec),
           OptionType::kUInt, OptionVerificationType::kNormal,
           OptionTypeFlags::kMutable}},
+        {"refresh_options_sec",
+         {offsetof(struct MutableDBOptions, refresh_options_sec),
+          OptionType::kUInt, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
+        {"refresh_options_file",
+         {offsetof(struct MutableDBOptions, refresh_options_file),
+          OptionType::kString, OptionVerificationType::kNormal,
+          OptionTypeFlags::kMutable}},
         {"stats_history_buffer_size",
          {offsetof(struct MutableDBOptions, stats_history_buffer_size),
           OptionType::kSizeT, OptionVerificationType::kNormal,
@@ -982,6 +990,7 @@ MutableDBOptions::MutableDBOptions()
       delete_obsolete_files_period_micros(6ULL * 60 * 60 * 1000000),
       stats_dump_period_sec(600),
       stats_persist_period_sec(600),
+      refresh_options_sec(0),
       stats_history_buffer_size(1024 * 1024),
       max_open_files(-1),
       bytes_per_sync(0),
@@ -1002,6 +1011,8 @@ MutableDBOptions::MutableDBOptions(const DBOptions& options)
           options.delete_obsolete_files_period_micros),
       stats_dump_period_sec(options.stats_dump_period_sec),
       stats_persist_period_sec(options.stats_persist_period_sec),
+      refresh_options_sec(options.refresh_options_sec),
+      refresh_options_file(options.refresh_options_file),
       stats_history_buffer_size(options.stats_history_buffer_size),
       max_open_files(options.max_open_files),
       bytes_per_sync(options.bytes_per_sync),
@@ -1033,6 +1044,12 @@ void MutableDBOptions::Dump(Logger* log) const {
                    stats_dump_period_sec);
   ROCKS_LOG_HEADER(log, "                Options.stats_persist_period_sec: %d",
                    stats_persist_period_sec);
+  ROCKS_LOG_HEADER(log, "                Options.refresh_options_sec: %d",
+                   refresh_options_sec);
+  if (refresh_options_sec > 0 && !refresh_options_file.empty()) {
+    ROCKS_LOG_HEADER(log, "                Options.refresh_options_file: %s",
+                     refresh_options_file.c_str());
+  }
   ROCKS_LOG_HEADER(
       log,
       "                Options.stats_history_buffer_size: %" ROCKSDB_PRIszt,

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -130,6 +130,8 @@ struct MutableDBOptions {
   uint64_t delete_obsolete_files_period_micros;
   unsigned int stats_dump_period_sec;
   unsigned int stats_persist_period_sec;
+  unsigned int refresh_options_sec;
+  std::string refresh_options_file;
   size_t stats_history_buffer_size;
   int max_open_files;
   uint64_t bytes_per_sync;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -186,6 +186,8 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.lowest_used_cache_tier = immutable_db_options.lowest_used_cache_tier;
   options.enforce_single_del_contracts =
       immutable_db_options.enforce_single_del_contracts;
+  options.refresh_options_sec = mutable_db_options.refresh_options_sec;
+  options.refresh_options_file = mutable_db_options.refresh_options_file;
   return options;
 }
 

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -251,6 +251,7 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
        sizeof(FileTypeSet)},
       {offsetof(struct DBOptions, compaction_service),
        sizeof(std::shared_ptr<CompactionService>)},
+      {offsetof(struct DBOptions, refresh_options_file), sizeof(std::string)},
   };
 
   char* options_ptr = new char[sizeof(DBOptions)];

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -361,6 +361,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "lowest_used_cache_tier=kNonVolatileBlockTier;"
                              "allow_data_in_errors=false;"
                              "enforce_single_del_contracts=false;"
+                             "refresh_options_sec=0;"
+                             "refresh_options_file=Options.new;"
                              "use_dynamic_delay=true",
                              new_options));
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1460,6 +1460,12 @@ DEFINE_int32(table_cache_numshardbits, 4, "");
 DEFINE_string(filter_uri, "", "URI for registry FilterPolicy");
 
 #ifndef ROCKSDB_LITE
+DEFINE_int32(
+    refresh_options_sec, 0,
+    "Frequency (in secs) to look for a new options file (off by default)");
+DEFINE_string(refresh_options_file, "",
+              "File in which to look for new options");
+
 DEFINE_string(env_uri, "",
               "URI for registry Env lookup. Mutually exclusive with --fs_uri");
 DEFINE_string(fs_uri, "",
@@ -4439,6 +4445,8 @@ class Benchmark {
     options.manual_wal_flush = FLAGS_manual_wal_flush;
     options.wal_compression = FLAGS_wal_compression_e;
 #ifndef ROCKSDB_LITE
+    options.refresh_options_sec = FLAGS_refresh_options_sec;
+    options.refresh_options_file = FLAGS_refresh_options_file;
     options.ttl = FLAGS_fifo_compaction_ttl;
     options.compaction_options_fifo = CompactionOptionsFIFO(
         FLAGS_fifo_compaction_max_table_files_size_mb * 1024 * 1024,


### PR DESCRIPTION
Added a method and options to support reading configuration changes to options periodically while a process is running.  Every "refresh_options_sec", the periodic task scheduler runs a task to check if the "refresh_options_file" exists.  If it does, the file is loaded as an options file and the mutable options from the file are updated in the running process (via SetDBOptions and SetOptions).  Once updated, the refresh file is deleted.  If an error occurs, it will be written to the log file.

Note that the file is read as an Options file and must be a valid Options file.  This means that the file must have a DBOptions section and at least one ColumnFamilyOptions section.  Only options that are mutable can be in this file -- immutable options will cause an error and abort the processing.

Additionally, note that TableFactory options must be specified as part of the ColumnFamilyOptions.  For example, to change the block size, the "table_factory.block_size" option should be set in the appropriate ColumnFamilyOptions.  Options set in a TableFactory section will be ignored.

Currently tested manually via db_bench.  Unit tests will be forthcoming.