### PR TITLE
unit tests: fix db_test PurgeInfoLogs by creating unique db path (#273)

### DIFF
--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -45,12 +45,19 @@ std::string PerThreadDBPath(std::string dir, std::string name) {
   return dir + "/" + name + "_" + GetPidStr() + "_" + std::to_string(tid);
 }
 
+std::string PerThreadDBPath(std::string dir, std::string name,
+                            int64_t time_now) {
+  return dir + "/" + name + "_" + GetPidStr() + "_" + std::to_string(time_now);
+}
+
 std::string PerThreadDBPath(std::string name) {
   return PerThreadDBPath(test::TmpDir(), name);
 }
 
 std::string PerThreadDBPath(Env* env, std::string name) {
-  return PerThreadDBPath(test::TmpDir(env), name);
+  int64_t time;
+  env->GetCurrentTime(&time);
+  return PerThreadDBPath(test::TmpDir(env), name, time);
 }
 
 int RandomSeed() {


### PR DESCRIPTION
create a unique db path for each new db opened in a suite. the PerThreadDBPath creates a db path based on the PID and the thread so that every test in the suite (e.g. db_test) has the exact same db path. this leads to unwanted leftovers which caused an error in PurgeInfoLogs.