### PR TITLE
Use the Test Name for the dbname when running unit tests

### DIFF
--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -88,7 +88,7 @@ DBTestBase::DBTestBase(const std::string path, bool env_do_fsync)
   env_->SetBackgroundThreads(1, Env::LOW);
   env_->SetBackgroundThreads(1, Env::HIGH);
   env_->skip_fsync_ = !env_do_fsync;
-  dbname_ = test::PerThreadDBPath(env_, path);
+  dbname_ = test::PerThreadDBPath(env_, test::GetTestNameForDB(path));
   alternative_wal_dir_ = dbname_ + "/wal";
   alternative_db_log_dir_ = dbname_ + "/db_log_dir";
   auto options = CurrentOptions();

--- a/test_util/testharness.cc
+++ b/test_util/testharness.cc
@@ -33,6 +33,30 @@ std::string GetPidStr() { return std::to_string(getpid()); }
   }
 }
 
+// If suggested is empty, the name will be <test case>-<test name>
+// Replaces all of the "/" in the test case/name with "_", so that they will not
+// appear as directories
+std::string GetTestNameForDB(const std::string& suggested) {
+  const testing::TestInfo* const test_info =
+      testing::UnitTest::GetInstance()->current_test_info();
+  std::string test_name = test_info->name();
+  std::string test_case = test_info->test_case_name();
+  auto pos = test_case.find("/");
+  if (pos != test_case.npos && !suggested.empty()) {
+    test_case = suggested;
+  } else {
+    while (pos != test_case.npos) {
+      test_case[pos] = '_';
+      pos = test_case.find("/", pos);
+    }
+  }
+  for (pos = test_name.find("/"); pos != test_name.npos;
+       pos = test_name.find("/", pos)) {
+    test_name[pos] = '_';
+  }
+  return test_case + "-" + test_name;
+}
+
 std::string TmpDir(Env* env) {
   std::string dir;
   Status s = env->GetTestDirectory(&dir);

--- a/test_util/testharness.h
+++ b/test_util/testharness.h
@@ -57,6 +57,9 @@
 namespace ROCKSDB_NAMESPACE {
 namespace test {
 
+// Return a name of the DB for this test, based on the test case/name
+std::string GetTestNameForDB(const std::string& suggested = "");
+
 // Return the directory to use for temporary storage.
 std::string TmpDir(Env* env = Env::Default());
 


### PR DESCRIPTION
This PR is based on the following [RocksDB PR](https://github.com/facebook/rocksdb/pull/10000).

The name of the database directory can be based on the name of the test itself.  This allows multiple tests in the same test class to use different database directories rather than all going to the same or similar directories.

This change can also help in debugging and KEEP_DB tests, as the directory after the test run can be spotted by its name (which is based on the name of the test).