### PR TITLE
Dynamic Delay: CFs wont override each other (#358)

### DIFF
--- a/speedb/version.h
+++ b/speedb/version.h
@@ -17,7 +17,7 @@
 
 #define SPEEDB_MAJOR 2
 #define SPEEDB_MINOR 2
-#define SPEEDB_PATCH 0
+#define SPEEDB_PATCH 1
 
 namespace ROCKSDB_NAMESPACE {
 


### PR DESCRIPTION
Currently, in a setting of multiple cfs, the delayed_write_rate_ value is overridden by the latest cf that entered a delay state. so if a cf registered a delay state that is less severe than the previous cf, it will override the previous value of delayed_write_rate_ with a higher rate than the system should use.

fix it by storing the delay requirements of all the CFs in the write controller and only set a new delayed_write_rate_ when its the min value from all entries stored.