### PR TITLE
ci job test_fuzz - removed saving logs to s3, it is not needed as the…

### DIFF
--- a/.github/workflows/test_fuzz.yml
+++ b/.github/workflows/test_fuzz.yml
@@ -3,11 +3,6 @@ name: Fuzz Test
 on:
   workflow_dispatch:
   workflow_call:
-    secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
 
 jobs:
   Fuzz:
@@ -25,18 +20,8 @@ jobs:
         run: |
           echo "nameserver 8.8.8.8" > /etc/resolv.conf
           apt update && apt install -y sudo python3 git clang-tools cmake make automake ucommon-utils libtool gettext pkg-config build-essential clang-10 zlib1g-dev libbz2-dev ninja-build liblzma-dev autoconf libsnappy-dev libzstd-dev liblz4-dev binutils m4 g++-10 unzip
-          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-          unzip awscliv2.zip
-          sudo ./aws/install
       
       - uses: actions/checkout@v3
-
-      - name: Configure AWS credentials from Test account
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-2
 
       - name: ${{ matrix.name }}
         run: |
@@ -64,8 +49,3 @@ jobs:
            mkdir -p $GITHUB_WORKSPACE/out/
            ASAN_OPTIONS=detect_odr_violation=0 $GITHUB_WORKSPACE/fuzz/${{ matrix.name }} 2>&1 | tee $GITHUB_WORKSPACE/out/${{ matrix.name }}.log
            tail -20 $GITHUB_WORKSPACE/out/${{ matrix.name }}.log | grep "==AddressSanitizer. Thread limit (4194304 threads) exceeded\. Dying\." || { echo "${{ matrix.name }} failed!" && false; }
-           
-      - name: Copy ${{ matrix.name }} logs to S3 due to failure
-        if: steps.${{ matrix.name }}.outcome == 'failure'
-        run: |
-          aws s3 cp $GITHUB_WORKSPACE/out/${{ matrix.name }}.log s3://spdb-github-ci/$GITHUB_SHA-${{ matrix.name }}.log


### PR DESCRIPTION
ci job test_fuzz - removed saving logs to s3. Saving logs is redundant and removing this part will allow triggering this workload by external contributors 