### PR TITLE
346 global delayed write rate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1452,6 +1452,7 @@ if(WITH_TESTS)
         db/write_batch_test.cc
         db/write_callback_test.cc
         db/write_controller_test.cc
+        db/global_write_controller_test.cc
         env/env_test.cc
         env/io_posix_test.cc
         env/mock_env_test.cc

--- a/Makefile
+++ b/Makefile
@@ -1647,6 +1647,9 @@ write_batch_test: $(OBJ_DIR)/db/write_batch_test.o $(TEST_LIBRARY) $(LIBRARY)
 write_controller_test: $(OBJ_DIR)/db/write_controller_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 
+global_write_controller_test: $(OBJ_DIR)/db/global_write_controller_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)
+
 merge_helper_test: $(OBJ_DIR)/db/merge_helper_test.o $(TEST_LIBRARY) $(LIBRARY)
 	$(AM_LINK)
 

--- a/TARGETS
+++ b/TARGETS
@@ -5414,6 +5414,12 @@ cpp_unittest_wrapper(name="full_filter_block_test",
             extra_compiler_flags=[])
 
 
+cpp_unittest_wrapper(name="global_write_controller_test",
+            srcs=["db/global_write_controller_test.cc"],
+            deps=[":rocksdb_test_lib"],
+            extra_compiler_flags=[])
+
+
 cpp_unittest_wrapper(name="hash_table_test",
             srcs=["utilities/persistent_cache/hash_table_test.cc"],
             deps=[":rocksdb_test_lib"],

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -760,6 +760,9 @@ void ColumnFamilyData::SetDropped() {
   // can't drop default CF
   assert(id_ != 0);
   dropped_ = true;
+  if (column_family_set_->write_controller()->is_dynamic_delay()) {
+    column_family_set_->DeleteSelfFromMapAndMaybeUpdateDelayRate(id_);
+  }
   write_controller_token_.reset();
 
   // remove from column_family_set
@@ -907,6 +910,10 @@ double ColumnFamilyData::TEST_CalculateWriteDelayDivider(
       compaction_needed_bytes, mutable_cf_options, write_stall_cause);
 }
 
+uint64_t ColumnFamilyData::UpdateCFRate(uint32_t id, uint64_t write_rate) {
+  return column_family_set_->UpdateCFRate(id, write_rate);
+}
+
 std::unique_ptr<WriteControllerToken> ColumnFamilyData::DynamicSetupDelay(
     WriteController* write_controller, uint64_t compaction_needed_bytes,
     const MutableCFOptions& mutable_cf_options,
@@ -922,7 +929,11 @@ std::unique_ptr<WriteControllerToken> ColumnFamilyData::DynamicSetupDelay(
     write_rate = kMinWriteRate;
   }
 
-  return write_controller->GetDelayToken(write_rate);
+  // GetDelayToken returns a DelayWriteToken and also sets the
+  // delayed_write_rate_ which is used by all cfs and dbs using this write
+  // controller. because it also sets the delayed_write_rate_, we need to set
+  // only the smallest active delay request.
+  return write_controller->GetDelayToken(UpdateCFRate(id_, write_rate));
 }
 
 std::pair<WriteStallCondition, ColumnFamilyData::WriteStallCause>
@@ -1048,7 +1059,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
   auto write_stall_condition = WriteStallCondition::kNormal;
   if (current_ != nullptr) {
     auto* vstorage = current_->storage_info();
-    auto write_controller = column_family_set_->write_controller_;
+    auto write_controller = column_family_set_->write_controller_ptr();
     uint64_t compaction_needed_bytes =
         vstorage->estimated_compaction_needed_bytes();
 
@@ -1065,13 +1076,16 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
 
     // GetWriteStallConditionAndCause returns the first condition met, so its
     // possible that a later condition will require a harder rate limiting.
-    // calculate all conditions with DynamicSetupDelay and reavaluate the
+    // calculate all conditions with DynamicSetupDelay and reevaluate the
     // write_stall_cause. this is only relevant in the kDelayed case.
-    if (dynamic_delay &&
-        write_stall_condition == WriteStallCondition::kDelayed) {
-      write_controller_token_ =
-          DynamicSetupDelay(write_controller, compaction_needed_bytes,
-                            mutable_cf_options, write_stall_cause);
+    if (dynamic_delay) {
+      if (write_stall_condition == WriteStallCondition::kDelayed) {
+        write_controller_token_ =
+            DynamicSetupDelay(write_controller, compaction_needed_bytes,
+                              mutable_cf_options, write_stall_cause);
+      } else {
+        column_family_set_->DeleteSelfFromMapAndMaybeUpdateDelayRate(id_);
+      }
     }
 
     if (write_stall_condition == WriteStallCondition::kStopped &&
@@ -1207,7 +1221,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
       // If the DB recovers from delay conditions, we reward with reducing
       // double the slowdown ratio. This is to balance the long term slowdown
       // increase signal.
-      if (needed_delay) {
+      if (needed_delay && !dynamic_delay) {
         uint64_t write_rate = write_controller->delayed_write_rate();
         write_controller->set_delayed_write_rate(static_cast<uint64_t>(
             static_cast<double>(write_rate) * kDelayRecoverSlowdownRatio));
@@ -1663,16 +1677,14 @@ FSDirectory* ColumnFamilyData::GetDataDir(size_t path_id) const {
   return data_dirs_[path_id].get();
 }
 
-ColumnFamilySet::ColumnFamilySet(const std::string& dbname,
-                                 const ImmutableDBOptions* db_options,
-                                 const FileOptions& file_options,
-                                 Cache* table_cache,
-                                 WriteBufferManager* _write_buffer_manager,
-                                 WriteController* _write_controller,
-                                 BlockCacheTracer* const block_cache_tracer,
-                                 const std::shared_ptr<IOTracer>& io_tracer,
-                                 const std::string& db_id,
-                                 const std::string& db_session_id)
+ColumnFamilySet::ColumnFamilySet(
+    const std::string& dbname, const ImmutableDBOptions* db_options,
+    const FileOptions& file_options, Cache* table_cache,
+    WriteBufferManager* _write_buffer_manager,
+    std::shared_ptr<WriteController> _write_controller,
+    BlockCacheTracer* const block_cache_tracer,
+    const std::shared_ptr<IOTracer>& io_tracer, const std::string& db_id,
+    const std::string& db_session_id)
     : max_column_family_(0),
       file_options_(file_options),
       dummy_cfd_(new ColumnFamilyData(
@@ -1692,6 +1704,7 @@ ColumnFamilySet::ColumnFamilySet(const std::string& dbname,
   // initialize linked list
   dummy_cfd_->prev_ = dummy_cfd_;
   dummy_cfd_->next_ = dummy_cfd_;
+  write_controller_->AddToDbRateMap(&cf_id_to_write_rate_);
 }
 
 ColumnFamilySet::~ColumnFamilySet() {
@@ -1705,6 +1718,7 @@ ColumnFamilySet::~ColumnFamilySet() {
   bool dummy_last_ref __attribute__((__unused__));
   dummy_last_ref = dummy_cfd_->UnrefAndTryDelete();
   assert(dummy_last_ref);
+  write_controller_->RemoveFromDbRateMap(&cf_id_to_write_rate_);
 }
 
 ColumnFamilyData* ColumnFamilySet::GetDefault() const {
@@ -1769,6 +1783,21 @@ ColumnFamilyData* ColumnFamilySet::CreateColumnFamily(
     default_cfd_cache_ = new_cfd;
   }
   return new_cfd;
+}
+
+// returns the min rate to set
+uint64_t ColumnFamilySet::UpdateCFRate(uint32_t id, uint64_t write_rate) {
+  return write_controller_->InsertToMapAndGetMinRate(id, &cf_id_to_write_rate_,
+                                                     write_rate);
+}
+
+// Removes the cf from the cf_id_to_write_rate_ map if it exists and if this cf
+// was the one with the min write rate then find and set a new min.
+void ColumnFamilySet::DeleteSelfFromMapAndMaybeUpdateDelayRate(uint32_t id) {
+  if (IsInRateMap(id)) {
+    write_controller_->DeleteSelfFromMapAndMaybeUpdateDelayRate(
+        id, &cf_id_to_write_rate_);
+  }
 }
 
 // under a DB mutex AND from a write thread

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -510,6 +510,9 @@ class ColumnFamilyData {
       const MutableCFOptions& mutable_cf_options,
       WriteStallCause& write_stall_cause);
 
+  // returns the min rate to set
+  uint64_t UpdateCFRate(uint32_t id, uint64_t write_rate);
+
  public:
   void set_initialized() { initialized_.store(true); }
 
@@ -714,7 +717,7 @@ class ColumnFamilySet {
                   const ImmutableDBOptions* db_options,
                   const FileOptions& file_options, Cache* table_cache,
                   WriteBufferManager* _write_buffer_manager,
-                  WriteController* _write_controller,
+                  std::shared_ptr<WriteController> _write_controller,
                   BlockCacheTracer* const block_cache_tracer,
                   const std::shared_ptr<IOTracer>& io_tracer,
                   const std::string& db_id, const std::string& db_session_id);
@@ -744,7 +747,19 @@ class ColumnFamilySet {
 
   WriteBufferManager* write_buffer_manager() { return write_buffer_manager_; }
 
-  WriteController* write_controller() { return write_controller_; }
+  const std::shared_ptr<WriteController>& write_controller() const {
+    return write_controller_;
+  }
+
+  uint64_t UpdateCFRate(uint32_t id, uint64_t write_rate);
+
+  bool IsInRateMap(uint32_t id) { return cf_id_to_write_rate_.count(id); }
+
+  // try and remove the cf id from WriteController::cf_id_to_write_rate_.
+  // if successful and it was the min rate, set the current minimum value.
+  void DeleteSelfFromMapAndMaybeUpdateDelayRate(uint32_t id);
+
+  WriteController* write_controller_ptr() { return write_controller_.get(); }
 
  private:
   friend class ColumnFamilyData;
@@ -776,11 +791,13 @@ class ColumnFamilySet {
   const ImmutableDBOptions* const db_options_;
   Cache* table_cache_;
   WriteBufferManager* write_buffer_manager_;
-  WriteController* write_controller_;
+  std::shared_ptr<WriteController> write_controller_;
   BlockCacheTracer* const block_cache_tracer_;
   std::shared_ptr<IOTracer> io_tracer_;
   const std::string& db_id_;
   std::string db_session_id_;
+
+  std::unordered_map<uint32_t, uint64_t> cf_id_to_write_rate_;
 };
 
 // A wrapper for ColumnFamilySet that supports releasing DB mutex during each

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -234,7 +234,7 @@ class ColumnFamilyTestBase : public testing::Test {
     EXPECT_TRUE(dbfull()->GetIntProperty("rocksdb.is-write-stopped", &v));
     return (v == 1);
 #else
-    return dbfull()->TEST_write_controler().IsStopped();
+    return dbfull()->TEST_write_controler()->IsStopped();
 #endif  // !ROCKSDB_LITE
   }
 
@@ -245,10 +245,10 @@ class ColumnFamilyTestBase : public testing::Test {
         dbfull()->GetIntProperty("rocksdb.actual-delayed-write-rate", &v));
     return v;
 #else
-    if (!dbfull()->TEST_write_controler().NeedsDelay()) {
+    if (!dbfull()->TEST_write_controler()->NeedsDelay()) {
       return 0;
     }
-    return dbfull()->TEST_write_controler().delayed_write_rate();
+    return dbfull()->TEST_write_controler()->delayed_write_rate();
 #endif  // !ROCKSDB_LITE
   }
 
@@ -617,8 +617,16 @@ class ColumnFamilyTestWithDynamic
   void CheckAssertions(bool expected_is_db_write_stopped,
                        bool expected_needs_delay) {
     ASSERT_TRUE(IsDbWriteStopped() == expected_is_db_write_stopped);
-    ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay() ==
+    ASSERT_TRUE(dbfull()->TEST_write_controler()->NeedsDelay() ==
                 expected_needs_delay);
+  }
+
+  double PickMaxInDynamic(double original_divider, double previous_divider) {
+    double rate_divider_to_use = original_divider;
+    if (db_options_.use_dynamic_delay) {
+      rate_divider_to_use = std::max(original_divider, previous_divider);
+    }
+    return rate_divider_to_use;
   }
 };
 
@@ -1770,7 +1778,7 @@ TEST_P(ColumnFamilyTest, AutomaticAndManualCompactions) {
   Reopen({default_cf, one, two});
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   std::atomic_bool cf_1_1{true};
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
@@ -1865,7 +1873,7 @@ TEST_P(ColumnFamilyTest, ManualAndAutomaticCompactions) {
   Reopen({default_cf, one, two});
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   // SETUP column family "one" -- universal style
   for (int i = 0; i < one.level0_file_num_compaction_trigger - 2; ++i) {
@@ -1957,7 +1965,7 @@ TEST_P(ColumnFamilyTest, SameCFManualManualCompactions) {
   Reopen({default_cf, one});
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   // SETUP column family "one" -- universal style
   for (int i = 0; i < one.level0_file_num_compaction_trigger - 2; ++i) {
@@ -2057,7 +2065,7 @@ TEST_P(ColumnFamilyTest, SameCFManualAutomaticCompactions) {
   Reopen({default_cf, one});
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   // SETUP column family "one" -- universal style
   for (int i = 0; i < one.level0_file_num_compaction_trigger - 2; ++i) {
@@ -2148,7 +2156,7 @@ TEST_P(ColumnFamilyTest, SameCFManualAutomaticCompactionsLevel) {
   Reopen({default_cf, one});
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   // SETUP column family "one" -- level style
   for (int i = 0; i < one.level0_file_num_compaction_trigger - 2; ++i) {
@@ -2245,7 +2253,7 @@ TEST_P(ColumnFamilyTest, SameCFAutomaticManualCompactions) {
   Reopen({default_cf, one});
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   std::atomic_bool cf_1_1{true};
   std::atomic_bool cf_1_2{true};
@@ -2959,24 +2967,24 @@ TEST_P(ColumnFamilyTestWithDynamic, WriteStallSingleColumnFamily) {
                                mutable_cf_options, NotStopped, NotDelayed));
 
   mutable_cf_options.disable_auto_compactions = true;
-  dbfull()->TEST_write_controler().set_delayed_write_rate(kBaseRate);
+  dbfull()->TEST_write_controler()->set_delayed_write_rate(kBaseRate);
   RecalculateWriteStallConditions(cfd, mutable_cf_options);
   ASSERT_TRUE(!IsDbWriteStopped());
-  ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(!dbfull()->TEST_write_controler()->NeedsDelay());
 
   rate_divider = CALL_WRAPPER(SetDelayAndCalculateRate(
       cfd, 0 Gb, 0 /* times_delayed*/, mutable_cf_options, NotStopped,
       NotDelayed, 50 /* l0_files*/));
   ASSERT_EQ(0, GetDbDelayedWriteRate());
   ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
-            dbfull()->TEST_write_controler().delayed_write_rate());
+            dbfull()->TEST_write_controler()->delayed_write_rate());
 
   rate_divider = CALL_WRAPPER(SetDelayAndCalculateRate(
       cfd, 300 Gb, 0 /* times_delayed*/, mutable_cf_options, NotStopped,
       NotDelayed, 60 /* l0_files*/));
   ASSERT_EQ(0, GetDbDelayedWriteRate());
   ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
-            dbfull()->TEST_write_controler().delayed_write_rate());
+            dbfull()->TEST_write_controler()->delayed_write_rate());
 
   mutable_cf_options.disable_auto_compactions = false;
   rate_divider = CALL_WRAPPER(SetDelayAndCalculateRate(
@@ -3081,55 +3089,65 @@ TEST_P(ColumnFamilyTestWithDynamic, WriteStallTwoColumnFamilies) {
   bool Delayed = true;
   bool NotDelayed = false;
   double rate_divider;
+  double rate_divider1;
+  double rate_divider_to_use;
 
   rate_divider = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd, 50 Gb, 0 /* times_delayed*/,
                                mutable_cf_options, NotStopped, NotDelayed));
 
-  rate_divider = CALL_WRAPPER(
+  rate_divider1 = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd1, 201 Gb, 0 /* times_delayed*/,
                                mutable_cf_options1, NotStopped, NotDelayed));
 
-  rate_divider = CALL_WRAPPER(
+  rate_divider1 = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd1, 600 Gb, 0 /* times_delayed*/,
                                mutable_cf_options1, NotStopped, Delayed));
-  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
+  rate_divider_to_use = PickMaxInDynamic(rate_divider1, rate_divider);
+
+  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider_to_use),
             GetDbDelayedWriteRate());
 
   rate_divider = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd, 70 Gb, 0 /* times_delayed*/,
                                mutable_cf_options, NotStopped, Delayed));
-  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
+  rate_divider_to_use = PickMaxInDynamic(rate_divider, rate_divider1);
+  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider_to_use),
             GetDbDelayedWriteRate());
 
-  rate_divider = CALL_WRAPPER(
+  rate_divider1 = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd1, 800 Gb, 1 /* times_delayed*/,
                                mutable_cf_options1, NotStopped, Delayed));
-  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
+  rate_divider_to_use = PickMaxInDynamic(rate_divider1, rate_divider);
+  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider_to_use),
             GetDbDelayedWriteRate());
 
   rate_divider = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd, 300 Gb, 2 /* times_delayed*/,
                                mutable_cf_options, NotStopped, Delayed));
-  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
+  rate_divider_to_use = PickMaxInDynamic(rate_divider, rate_divider1);
+  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider_to_use),
             GetDbDelayedWriteRate());
 
-  rate_divider = CALL_WRAPPER(
+  rate_divider1 = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd1, 700 Gb, 1 /* times_delayed*/,
                                mutable_cf_options1, NotStopped, Delayed));
-  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
+  rate_divider_to_use = PickMaxInDynamic(rate_divider1, rate_divider);
+  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider_to_use),
             GetDbDelayedWriteRate());
 
   rate_divider = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd, 500 Gb, 2 /* times_delayed*/,
                                mutable_cf_options, NotStopped, Delayed));
-  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
+  rate_divider_to_use = PickMaxInDynamic(rate_divider, rate_divider1);
+  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider_to_use),
             GetDbDelayedWriteRate());
 
-  rate_divider = CALL_WRAPPER(
+  rate_divider1 = CALL_WRAPPER(
       SetDelayAndCalculateRate(cfd1, 600 Gb, 1 /* times_delayed*/,
                                mutable_cf_options1, NotStopped, Delayed));
-  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider),
+  rate_divider_to_use = PickMaxInDynamic(rate_divider1, rate_divider);
+  ASSERT_EQ(static_cast<uint64_t>(kBaseRate / rate_divider_to_use),
             GetDbDelayedWriteRate());
 }
 

--- a/db/compaction/compaction_job.cc
+++ b/db/compaction/compaction_job.cc
@@ -1983,7 +1983,7 @@ Env::IOPriority CompactionJob::GetRateLimiterPriority() {
   if (versions_ && versions_->GetColumnFamilySet() &&
       versions_->GetColumnFamilySet()->write_controller()) {
     WriteController* write_controller =
-        versions_->GetColumnFamilySet()->write_controller();
+        versions_->GetColumnFamilySet()->write_controller_ptr();
     if (write_controller->NeedsDelay() || write_controller->IsStopped()) {
       return Env::IO_USER;
     }

--- a/db/compaction/compaction_job_test.cc
+++ b/db/compaction/compaction_job_test.cc
@@ -211,11 +211,12 @@ class CompactionJobTestBase : public testing::Test {
         mutable_cf_options_(cf_options_),
         mutable_db_options_(),
         table_cache_(NewLRUCache(50000, 16)),
-        write_controller_(db_options_.use_dynamic_delay),
+        write_controller_(
+            std::make_shared<WriteController>(db_options_.use_dynamic_delay)),
         write_buffer_manager_(db_options_.db_write_buffer_size),
         versions_(new VersionSet(
             dbname_, &db_options_, env_options_, table_cache_.get(),
-            &write_buffer_manager_, &write_controller_,
+            &write_buffer_manager_, write_controller_,
             /*block_cache_tracer=*/nullptr,
             /*io_tracer=*/nullptr, /*db_id*/ "", /*db_session_id*/ "")),
         shutting_down_(false),
@@ -535,7 +536,7 @@ class CompactionJobTestBase : public testing::Test {
 
     versions_.reset(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     compaction_job_stats_.Reset();
@@ -685,7 +686,7 @@ class CompactionJobTestBase : public testing::Test {
     ASSERT_EQ(compaction_job.GetRateLimiterPriority(), Env::IO_LOW);
 
     WriteController* write_controller =
-        compaction_job.versions_->GetColumnFamilySet()->write_controller();
+        compaction_job.versions_->GetColumnFamilySet()->write_controller_ptr();
 
     {
       // When the state from WriteController is Delayed.
@@ -713,7 +714,7 @@ class CompactionJobTestBase : public testing::Test {
   MutableCFOptions mutable_cf_options_;
   MutableDBOptions mutable_db_options_;
   std::shared_ptr<Cache> table_cache_;
-  WriteController write_controller_;
+  std::shared_ptr<WriteController> write_controller_;
   WriteBufferManager write_buffer_manager_;
   std::unique_ptr<VersionSet> versions_;
   InstrumentedMutex mutex_;
@@ -1994,7 +1995,7 @@ TEST_F(CompactionJobIOPriorityTest, WriteControllerStateDelayed) {
   ASSERT_EQ(2U, files.size());
   {
     std::unique_ptr<WriteControllerToken> delay_token =
-        write_controller_.GetDelayToken(1000000);
+        write_controller_->GetDelayToken(1000000);
     RunCompaction({files}, {input_level}, {expected_results}, {},
                   kMaxSequenceNumber, 1, false, {kInvalidBlobFileNumber}, false,
                   Env::IO_USER, Env::IO_USER);
@@ -2011,7 +2012,7 @@ TEST_F(CompactionJobIOPriorityTest, WriteControllerStateStalled) {
   ASSERT_EQ(2U, files.size());
   {
     std::unique_ptr<WriteControllerToken> stop_token =
-        write_controller_.GetStopToken();
+        write_controller_->GetStopToken();
     RunCompaction({files}, {input_level}, {expected_results}, {},
                   kMaxSequenceNumber, 1, false, {kInvalidBlobFileNumber}, false,
                   Env::IO_USER, Env::IO_USER);

--- a/db/db_compaction_test.cc
+++ b/db/db_compaction_test.cc
@@ -1635,7 +1635,7 @@ TEST_F(DBCompactionTest, DISABLED_ManualPartialFill) {
   DestroyAndReopen(options);
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
   int32_t value_size = 10 * 1024;  // 10 KB
 
   // Add 2 non-overlapping files
@@ -3607,7 +3607,7 @@ TEST_F(DBCompactionTest, CompactFilesPendingL0Bug) {
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
 
   auto schedule_multi_compaction_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   // Files 0-3 will be included in an L0->L1 compaction.
   //
@@ -5415,7 +5415,7 @@ TEST_P(RoundRobinSubcompactionsAgainstPressureToken, PressureTokenTest) {
   std::unique_ptr<WriteControllerToken> pressure_token;
   if (grab_pressure_token_) {
     pressure_token =
-        dbfull()->TEST_write_controler().GetCompactionPressureToken();
+        dbfull()->TEST_write_controler()->GetCompactionPressureToken();
   }
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstPressureToken:2");
 
@@ -5499,7 +5499,7 @@ TEST_P(RoundRobinSubcompactionsAgainstResources, SubcompactionsUsingResources) {
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstResources:0");
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstResources:1");
   auto pressure_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstResources:2");
   TEST_SYNC_POINT("RoundRobinSubcompactionsAgainstResources:3");

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -197,8 +197,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
       write_buffer_manager_(immutable_db_options_.write_buffer_manager.get()),
       write_thread_(immutable_db_options_),
       nonmem_write_thread_(immutable_db_options_),
-      write_controller_(immutable_db_options_.use_dynamic_delay,
-                        mutable_db_options_.delayed_write_rate),
+      write_controller_(immutable_db_options_.write_controller),
       last_batch_group_size_(0),
       unscheduled_flushes_(0),
       unscheduled_compactions_(0),
@@ -283,7 +282,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname,
 
   versions_.reset(new VersionSet(dbname_, &immutable_db_options_, file_options_,
                                  table_cache_.get(), write_buffer_manager_,
-                                 &write_controller_, &block_cache_tracer_,
+                                 write_controller_, &block_cache_tracer_,
                                  io_tracer_, db_id_, db_session_id_));
   column_family_memtables_.reset(
       new ColumnFamilyMemTablesImpl(versions_->GetColumnFamilySet()));
@@ -1455,7 +1454,7 @@ Status DBImpl::SetDBOptions(
         return s;
       }
 
-      write_controller_.set_max_delayed_write_rate(
+      write_controller_->set_max_delayed_write_rate(
           new_options.delayed_write_rate);
       table_cache_.get()->SetCapacity(new_options.max_open_files == -1
                                           ? TableCache::kInfiniteCapacity

--- a/db/db_impl/db_impl.h
+++ b/db/db_impl/db_impl.h
@@ -889,7 +889,11 @@ class DBImpl : public DB {
     return num_running_compactions_;
   }
 
-  const WriteController& write_controller() { return write_controller_; }
+  const std::shared_ptr<WriteController>& write_controller() const {
+    return write_controller_;
+  }
+
+  WriteController* write_controller_ptr() { return write_controller_.get(); }
 
   // hollow transactions shell used for recovery.
   // these will then be passed to TransactionDB so that
@@ -1148,7 +1152,9 @@ class DBImpl : public DB {
 
   Cache* TEST_table_cache() { return table_cache_.get(); }
 
-  WriteController& TEST_write_controler() { return write_controller_; }
+  const std::shared_ptr<WriteController>& TEST_write_controler() {
+    return write_controller_;
+  }
 
   uint64_t TEST_FindMinLogContainingOutstandingPrep();
   uint64_t TEST_FindMinPrepLogReferencedByMemTable();
@@ -2460,7 +2466,7 @@ class DBImpl : public DB {
   // in 2PC to batch the prepares separately from the serial commit.
   WriteThread nonmem_write_thread_;
 
-  WriteController write_controller_;
+  std::shared_ptr<WriteController> write_controller_;
 
   // Size of the last batch group. In slowdown mode, next write needs to
   // sleep if it uses up the quota.

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -2541,7 +2541,7 @@ DBImpl::BGJobLimits DBImpl::GetBGJobLimits() const {
   return GetBGJobLimits(mutable_db_options_.max_background_flushes,
                         mutable_db_options_.max_background_compactions,
                         mutable_db_options_.max_background_jobs,
-                        write_controller_.NeedSpeedupCompaction());
+                        write_controller_->NeedSpeedupCompaction());
 }
 
 DBImpl::BGJobLimits DBImpl::GetBGJobLimits(int max_background_flushes,

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -93,6 +93,16 @@ DBOptions SanitizeOptions(const std::string& dbname, const DBOptions& src,
     }
   }
 
+  if (!result.write_controller) {
+    result.write_controller.reset(new WriteController(
+        result.use_dynamic_delay, result.delayed_write_rate));
+  } else if (result.use_dynamic_delay == false) {
+    result.use_dynamic_delay = true;
+    ROCKS_LOG_WARN(
+        result.info_log,
+        "Global Write Controller is only possible with use_dynamic_delay");
+  }
+
   if (result.WAL_ttl_seconds > 0 || result.WAL_size_limit_MB > 0) {
     result.recycle_log_file_num = false;
   }

--- a/db/db_impl/db_impl_secondary.cc
+++ b/db/db_impl/db_impl_secondary.cc
@@ -722,7 +722,7 @@ Status DB::OpenAsSecondary(
   impl->versions_.reset(new ReactiveVersionSet(
       dbname, &impl->immutable_db_options_, impl->file_options_,
       impl->table_cache_.get(), impl->write_buffer_manager_,
-      &impl->write_controller_, impl->io_tracer_));
+      impl->write_controller_, impl->io_tracer_));
   impl->column_family_memtables_.reset(
       new ColumnFamilyMemTablesImpl(impl->versions_->GetColumnFamilySet()));
   impl->wal_in_db_path_ = impl->immutable_db_options_.IsWalDirSameAsDBPath();

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1163,8 +1163,8 @@ Status DBImpl::PreprocessWrite(const WriteOptions& write_options,
   PERF_TIMER_STOP(write_scheduling_flushes_compactions_time);
   PERF_TIMER_GUARD(write_pre_and_post_process_time);
 
-  if (UNLIKELY(status.ok() && (write_controller_.IsStopped() ||
-                               write_controller_.NeedsDelay()))) {
+  if (UNLIKELY(status.ok() && (write_controller_->IsStopped() ||
+                               write_controller_->NeedsDelay()))) {
     PERF_TIMER_STOP(write_pre_and_post_process_time);
     PERF_TIMER_GUARD(write_delay_time);
     // We don't know size of curent batch so that we always use the size
@@ -1747,8 +1747,11 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
   {
     StopWatch sw(immutable_db_options_.clock, stats_, WRITE_STALL,
                  &time_delayed);
+    mutex_.AssertHeld();
+    mutex_.Unlock();
     uint64_t delay =
-        write_controller_.GetDelay(immutable_db_options_.clock, num_bytes);
+        write_controller_->GetDelay(immutable_db_options_.clock, num_bytes);
+    mutex_.Lock();
     if (delay > 0) {
       if (write_options.no_slowdown) {
         return Status::Incomplete("Write stall");
@@ -1766,7 +1769,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
       // case of sleep imprecision, rounding, etc.)
       const uint64_t kDelayInterval = 1001;
       uint64_t stall_end = sw.start_time() + delay;
-      while (write_controller_.NeedsDelay()) {
+      while (write_controller_->NeedsDelay()) {
         if (immutable_db_options_.clock->NowMicros() >= stall_end) {
           // We already delayed this write `delay` microseconds
           break;
@@ -1784,7 +1787,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
     // might wait here indefinitely as the background compaction may never
     // finish successfully, resulting in the stall condition lasting
     // indefinitely
-    while (error_handler_.GetBGError().ok() && write_controller_.IsStopped()) {
+    while (error_handler_.GetBGError().ok() && write_controller_->IsStopped()) {
       if (write_options.no_slowdown) {
         return Status::Incomplete("Write stall");
       }
@@ -1794,7 +1797,15 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
       // fail any pending writers with no_slowdown
       write_thread_.BeginWriteStall();
       TEST_SYNC_POINT("DBImpl::DelayWrite:Wait");
-      bg_cv_.Wait();
+      // check here if another db is able to wake all the others.
+      // in a unit test:
+      // this db stops writing since another db is in a stop condition. make
+      // sure this db exits the stop condition.
+      mutex_.Unlock();
+
+      write_controller_->WaitOnCV(error_handler_);
+
+      mutex_.Lock();
       write_thread_.EndWriteStall();
     }
   }
@@ -1809,7 +1820,7 @@ Status DBImpl::DelayWrite(uint64_t num_bytes,
   // writes, we can ignore any background errors and allow the write to
   // proceed
   Status s;
-  if (write_controller_.IsStopped()) {
+  if (write_controller_->IsStopped()) {
     // If writes are still stopped, it means we bailed due to a background
     // error
     s = Status::Incomplete(error_handler_.GetBGError().ToString());
@@ -1858,7 +1869,7 @@ Status DBImpl::ThrottleLowPriWritesIfNeeded(const WriteOptions& write_options,
   // it in this case.
   // If we need to speed compaction, it means the compaction is left behind
   // and we start to limit low pri writes to a limit.
-  if (write_controller_.NeedSpeedupCompaction()) {
+  if (write_controller_->NeedSpeedupCompaction()) {
     if (allow_2pc() && (my_batch->HasCommit() || my_batch->HasRollback())) {
       // For 2PC, we only rate limit prepare, not commit.
       return Status::OK();
@@ -1872,7 +1883,7 @@ Status DBImpl::ThrottleLowPriWritesIfNeeded(const WriteOptions& write_options,
       // a chance to run. Now we guarantee we are still slowly making
       // progress.
       PERF_TIMER_GUARD(write_delay_time);
-      write_controller_.low_pri_rate_limiter()->Request(
+      write_controller_->low_pri_rate_limiter()->Request(
           my_batch->GetDataSize(), Env::IO_HIGH, nullptr /* stats */,
           RateLimiter::OpType::kWrite);
     }

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -536,8 +536,8 @@ TEST_F(DBOptionsTest, EnableAutoCompactionAndTriggerStall) {
       }
       Reopen(options);
       ASSERT_OK(dbfull()->TEST_WaitForCompact());
-      ASSERT_FALSE(dbfull()->TEST_write_controler().IsStopped());
-      ASSERT_FALSE(dbfull()->TEST_write_controler().NeedsDelay());
+      ASSERT_FALSE(dbfull()->TEST_write_controler()->IsStopped());
+      ASSERT_FALSE(dbfull()->TEST_write_controler()->NeedsDelay());
 
       SyncPoint::GetInstance()->LoadDependency(
           {{"DBOptionsTest::EnableAutoCompactionAndTriggerStall:1",
@@ -565,26 +565,26 @@ TEST_F(DBOptionsTest, EnableAutoCompactionAndTriggerStall) {
 
       switch (option_type) {
         case 0:
-          ASSERT_TRUE(dbfull()->TEST_write_controler().IsStopped());
+          ASSERT_TRUE(dbfull()->TEST_write_controler()->IsStopped());
           break;
         case 1:
-          ASSERT_FALSE(dbfull()->TEST_write_controler().IsStopped());
-          ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
+          ASSERT_FALSE(dbfull()->TEST_write_controler()->IsStopped());
+          ASSERT_TRUE(dbfull()->TEST_write_controler()->NeedsDelay());
           break;
         case 2:
-          ASSERT_TRUE(dbfull()->TEST_write_controler().IsStopped());
+          ASSERT_TRUE(dbfull()->TEST_write_controler()->IsStopped());
           break;
         case 3:
-          ASSERT_FALSE(dbfull()->TEST_write_controler().IsStopped());
-          ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
+          ASSERT_FALSE(dbfull()->TEST_write_controler()->IsStopped());
+          ASSERT_TRUE(dbfull()->TEST_write_controler()->NeedsDelay());
           break;
       }
       TEST_SYNC_POINT("DBOptionsTest::EnableAutoCompactionAndTriggerStall:3");
 
       // Background compaction executed.
       ASSERT_OK(dbfull()->TEST_WaitForCompact());
-      ASSERT_FALSE(dbfull()->TEST_write_controler().IsStopped());
-      ASSERT_FALSE(dbfull()->TEST_write_controler().NeedsDelay());
+      ASSERT_FALSE(dbfull()->TEST_write_controler()->IsStopped());
+      ASSERT_FALSE(dbfull()->TEST_write_controler()->NeedsDelay());
     }
   }
 }
@@ -617,7 +617,7 @@ TEST_F(DBOptionsTest, SetBackgroundCompactionThreads) {
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
   ASSERT_OK(dbfull()->SetDBOptions({{"max_background_compactions", "3"}}));
   ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
-  auto stop_token = dbfull()->TEST_write_controler().GetStopToken();
+  auto stop_token = dbfull()->TEST_write_controler()->GetStopToken();
   ASSERT_EQ(3, dbfull()->TEST_BGCompactionsAllowed());
 }
 
@@ -658,7 +658,7 @@ TEST_F(DBOptionsTest, SetBackgroundJobs) {
     ASSERT_EQ(expected_max_flushes, dbfull()->TEST_BGFlushesAllowed());
     ASSERT_EQ(1, dbfull()->TEST_BGCompactionsAllowed());
 
-    auto stop_token = dbfull()->TEST_write_controler().GetStopToken();
+    auto stop_token = dbfull()->TEST_write_controler()->GetStopToken();
 
     const int expected_max_compactions = 3 * expected_max_flushes;
 
@@ -701,10 +701,11 @@ TEST_F(DBOptionsTest, SetDelayedWriteRateOption) {
   options.delayed_write_rate = 2 * 1024U * 1024U;
   options.env = env_;
   Reopen(options);
-  ASSERT_EQ(2 * 1024U * 1024U, dbfull()->TEST_write_controler().max_delayed_write_rate());
+  ASSERT_EQ(2 * 1024U * 1024U,
+            dbfull()->TEST_write_controler()->max_delayed_write_rate());
 
   ASSERT_OK(dbfull()->SetDBOptions({{"delayed_write_rate", "20000"}}));
-  ASSERT_EQ(20000, dbfull()->TEST_write_controler().max_delayed_write_rate());
+  ASSERT_EQ(20000, dbfull()->TEST_write_controler()->max_delayed_write_rate());
 }
 
 TEST_F(DBOptionsTest, MaxTotalWalSizeChange) {

--- a/db/db_test.cc
+++ b/db/db_test.cc
@@ -235,7 +235,7 @@ TEST_F(DBTest, SkipDelay) {
       // when we do Put
       // TODO(myabandeh): this is time dependent and could potentially make
       // the test flaky
-      auto token = dbfull()->TEST_write_controler().GetDelayToken(1);
+      auto token = dbfull()->TEST_write_controler()->GetDelayToken(1);
       std::atomic<int> sleep_count(0);
       ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
           "DBImpl::DelayWrite:Sleep",
@@ -262,7 +262,7 @@ TEST_F(DBTest, SkipDelay) {
       ASSERT_GE(wait_count.load(), 0);
       token.reset();
 
-      token = dbfull()->TEST_write_controler().GetDelayToken(1000000);
+      token = dbfull()->TEST_write_controler()->GetDelayToken(1000000);
       wo.no_slowdown = false;
       ASSERT_OK(dbfull()->Put(wo, "foo3", large_value));
       ASSERT_GE(sleep_count.load(), 1);
@@ -297,7 +297,7 @@ TEST_F(DBTest, MixedSlowdownOptions) {
   // when we do Put
   // TODO(myabandeh): this is time dependent and could potentially make
   // the test flaky
-  auto token = dbfull()->TEST_write_controler().GetDelayToken(1);
+  auto token = dbfull()->TEST_write_controler()->GetDelayToken(1);
   std::atomic<int> sleep_count(0);
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::DelayWrite:BeginWriteStallDone", [&](void* /*arg*/) {
@@ -351,7 +351,7 @@ TEST_F(DBTest, MixedSlowdownOptionsInQueue) {
   // when we do Put
   // TODO(myabandeh): this is time dependent and could potentially make
   // the test flaky
-  auto token = dbfull()->TEST_write_controler().GetDelayToken(1);
+  auto token = dbfull()->TEST_write_controler()->GetDelayToken(1);
   std::atomic<int> sleep_count(0);
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::DelayWrite:Sleep", [&](void* /*arg*/) {
@@ -419,7 +419,7 @@ TEST_F(DBTest, MixedSlowdownOptionsStop) {
   // when we do Put
   // TODO(myabandeh): this is time dependent and could potentially make
   // the test flaky
-  auto token = dbfull()->TEST_write_controler().GetStopToken();
+  auto token = dbfull()->TEST_write_controler()->GetStopToken();
   std::atomic<int> wait_count(0);
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
       "DBImpl::DelayWrite:Wait", [&](void* /*arg*/) {
@@ -5326,7 +5326,7 @@ TEST_F(DBTest, DynamicCompactionOptions) {
     ASSERT_OK(Put(Key(count), rnd.RandomString(1024), wo));
     ASSERT_OK(dbfull()->TEST_FlushMemTable(true, true));
     count++;
-    if (dbfull()->TEST_write_controler().IsStopped()) {
+    if (dbfull()->TEST_write_controler()->IsStopped()) {
       for (auto& sleeping_task : sleeping_task_low) {
         sleeping_task.WakeUp();
       }
@@ -5360,7 +5360,7 @@ TEST_F(DBTest, DynamicCompactionOptions) {
     ASSERT_OK(Put(Key(count), rnd.RandomString(1024), wo));
     ASSERT_OK(dbfull()->TEST_FlushMemTable(true, true));
     count++;
-    if (dbfull()->TEST_write_controler().IsStopped()) {
+    if (dbfull()->TEST_write_controler()->IsStopped()) {
       for (auto& sleeping_task : sleeping_task_low) {
         sleeping_task.WakeUp();
       }
@@ -6683,7 +6683,7 @@ TEST_F(DBTest, SoftLimit) {
     ASSERT_OK(dbfull()->TEST_FlushMemTable(true, true));
     WaitForFlush();
   }
-  ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(dbfull()->TEST_write_controler()->NeedsDelay());
   ASSERT_TRUE(listener->CheckCondition(WriteStallCondition::kDelayed));
 
   for (auto& sleeping_task : sleeping_task_low) {
@@ -6700,7 +6700,7 @@ TEST_F(DBTest, SoftLimit) {
   //
   // The L1 file size is around 30KB.
   ASSERT_EQ(NumTableFilesAtLevel(1), 1);
-  ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(!dbfull()->TEST_write_controler()->NeedsDelay());
   ASSERT_TRUE(listener->CheckCondition(WriteStallCondition::kNormal));
 
   // Only allow one compactin going through.
@@ -6737,7 +6737,7 @@ TEST_F(DBTest, SoftLimit) {
   // Given level multiplier 10, estimated pending compaction is around 100KB
   // doesn't trigger soft_pending_compaction_bytes_limit
   ASSERT_EQ(NumTableFilesAtLevel(1), 1);
-  ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(!dbfull()->TEST_write_controler()->NeedsDelay());
   ASSERT_TRUE(listener->CheckCondition(WriteStallCondition::kNormal));
 
   // Create 3 L0 files, making score of L0 to be 3, higher than L0.
@@ -6760,13 +6760,13 @@ TEST_F(DBTest, SoftLimit) {
   // compaction is around 200KB
   // triggerring soft_pending_compaction_bytes_limit
   ASSERT_EQ(NumTableFilesAtLevel(1), 1);
-  ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(dbfull()->TEST_write_controler()->NeedsDelay());
   ASSERT_TRUE(listener->CheckCondition(WriteStallCondition::kDelayed));
 
   sleeping_task_low[0].WakeUp();
   sleeping_task_low[0].WaitUntilSleeping();
 
-  ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(!dbfull()->TEST_write_controler()->NeedsDelay());
   ASSERT_TRUE(listener->CheckCondition(WriteStallCondition::kNormal));
 
   // shrink level base so L2 will hit soft limit easier.
@@ -6776,7 +6776,7 @@ TEST_F(DBTest, SoftLimit) {
 
   ASSERT_OK(Put("", ""));
   ASSERT_OK(Flush());
-  ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(dbfull()->TEST_write_controler()->NeedsDelay());
   ASSERT_TRUE(listener->CheckCondition(WriteStallCondition::kDelayed));
 
   sleeping_task_low[0].WaitUntilSleeping();
@@ -6812,11 +6812,11 @@ TEST_F(DBTest, LastWriteBufferDelay) {
     for (int j = 0; j < kNumKeysPerMemtable; j++) {
       ASSERT_OK(Put(Key(j), ""));
     }
-    ASSERT_TRUE(!dbfull()->TEST_write_controler().NeedsDelay());
+    ASSERT_TRUE(!dbfull()->TEST_write_controler()->NeedsDelay());
   }
   // Inserting a new entry would create a new mem table, triggering slow down.
   ASSERT_OK(Put(Key(0), ""));
-  ASSERT_TRUE(dbfull()->TEST_write_controler().NeedsDelay());
+  ASSERT_TRUE(dbfull()->TEST_write_controler()->NeedsDelay());
 
   sleeping_task.WakeUp();
   sleeping_task.WaitUntilDone();

--- a/db/db_test2.cc
+++ b/db/db_test2.cc
@@ -2013,7 +2013,7 @@ TEST_F(DBTest2, CompactionStall) {
   DestroyAndReopen(options);
   // make sure all background compaction jobs can be scheduled
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   Random rnd(301);
 

--- a/db/db_test_util.cc
+++ b/db/db_test_util.cc
@@ -123,6 +123,25 @@ DBTestBase::~DBTestBase() {
   delete env_;
 }
 
+void DBTestBase::RecalculateWriteStallConditions(
+    DBImpl* dbimpl, ColumnFamilyData* cfd,
+    const MutableCFOptions& mutable_cf_options) {
+  // add lock to avoid race condition between
+  // `RecalculateWriteStallConditions` which writes to CFStats and
+  // background `DBImpl::DumpStats()` threads which read CFStats
+  dbimpl->TEST_LockMutex();
+  cfd->RecalculateWriteStallConditions(mutable_cf_options);
+  dbimpl->TEST_UnlockMutex();
+}
+
+bool DBTestBase::IsDbWriteStopped(DBImpl* dbimpl) {
+  return dbimpl->TEST_write_controler()->IsStopped();
+}
+
+bool DBTestBase::IsDbWriteDelayed(DBImpl* dbimpl) {
+  return dbimpl->TEST_write_controler()->NeedsDelay();
+}
+
 bool DBTestBase::ShouldSkipOptions(int option_config, int skip_mask) {
 #ifdef ROCKSDB_LITE
     // These options are not supported in ROCKSDB_LITE

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -1092,6 +1092,14 @@ class DBTestBase : public testing::Test {
 
   ~DBTestBase();
 
+  void RecalculateWriteStallConditions(
+      DBImpl* db, ColumnFamilyData* cfd,
+      const MutableCFOptions& mutable_cf_options);
+
+  bool IsDbWriteStopped(DBImpl* dbimpl);
+
+  bool IsDbWriteDelayed(DBImpl* dbimpl);
+
   static std::string Key(int i) {
     char buf[100];
     snprintf(buf, sizeof(buf), "key%06d", i);

--- a/db/db_universal_compaction_test.cc
+++ b/db/db_universal_compaction_test.cc
@@ -1692,7 +1692,7 @@ TEST_P(DBTestUniversalCompaction, ConcurrentBottomPriLowPriCompactions) {
   // Need to get a token to enable compaction parallelism up to
   // `max_background_compactions` jobs.
   auto pressure_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
   ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->LoadDependency(
       {// wait for the full compaction to be picked before adding files intended
        // for the second one.
@@ -1786,7 +1786,7 @@ TEST_P(DBTestUniversalCompaction, FinalSortedRunCompactFilesConflict) {
 
   // make sure compaction jobs can be parallelized
   auto stop_token =
-      dbfull()->TEST_write_controler().GetCompactionPressureToken();
+      dbfull()->TEST_write_controler()->GetCompactionPressureToken();
 
   ASSERT_OK(Put("key", "val"));
   ASSERT_OK(Flush());

--- a/db/db_wal_test.cc
+++ b/db/db_wal_test.cc
@@ -1259,11 +1259,10 @@ class RecoveryTestHelper {
 
     std::unique_ptr<VersionSet> versions;
     std::unique_ptr<WalManager> wal_manager;
-    WriteController write_controller(db_options.use_dynamic_delay);
 
     versions.reset(new VersionSet(
         test->dbname_, &db_options, file_options, table_cache.get(),
-        &write_buffer_manager, &write_controller,
+        &write_buffer_manager, db_options.write_controller,
         /*block_cache_tracer=*/nullptr,
         /*io_tracer=*/nullptr, /*db_id*/ "", /*db_session_id*/ ""));
 

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -1051,7 +1051,7 @@ Env::IOPriority FlushJob::GetRateLimiterPriorityForWrite() {
   if (versions_ && versions_->GetColumnFamilySet() &&
       versions_->GetColumnFamilySet()->write_controller()) {
     WriteController* write_controller =
-        versions_->GetColumnFamilySet()->write_controller();
+        versions_->GetColumnFamilySet()->write_controller_ptr();
     if (write_controller->IsStopped() || write_controller->NeedsDelay()) {
       return Env::IO_USER;
     }

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -40,7 +40,8 @@ class FlushJobTestBase : public testing::Test {
         db_options_(options_),
         column_family_names_({kDefaultColumnFamilyName, "foo", "bar"}),
         table_cache_(NewLRUCache(50000, 16)),
-        write_controller_(db_options_.use_dynamic_delay),
+        write_controller_(
+            std::make_shared<WriteController>(db_options_.use_dynamic_delay)),
         write_buffer_manager_(db_options_.db_write_buffer_size),
         shutting_down_(false),
         mock_table_factory_(new mock::MockTableFactory()) {}
@@ -127,7 +128,7 @@ class FlushJobTestBase : public testing::Test {
 
     versions_.reset(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     EXPECT_OK(versions_->Recover(column_families, false));
@@ -142,7 +143,7 @@ class FlushJobTestBase : public testing::Test {
   ImmutableDBOptions db_options_;
   const std::vector<std::string> column_family_names_;
   std::shared_ptr<Cache> table_cache_;
-  WriteController write_controller_;
+  std::shared_ptr<WriteController> write_controller_;
   WriteBufferManager write_buffer_manager_;
   ColumnFamilyOptions cf_options_;
   std::unique_ptr<VersionSet> versions_;
@@ -586,7 +587,7 @@ TEST_F(FlushJobTest, GetRateLimiterPriorityForWrite) {
   ASSERT_EQ(flush_job.GetRateLimiterPriorityForWrite(), Env::IO_HIGH);
 
   WriteController* write_controller =
-      flush_job.versions_->GetColumnFamilySet()->write_controller();
+      flush_job.versions_->GetColumnFamilySet()->write_controller_ptr();
 
   {
     // When the state from WriteController is Delayed.

--- a/db/global_write_controller_test.cc
+++ b/db/global_write_controller_test.cc
@@ -1,0 +1,290 @@
+// Copyright (C) 2023 Speedb Ltd. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "db/db_test_util.h"
+#include "db/write_controller.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// The param is whether dynamic_delay is used or not
+class GlobalWriteControllerTest : public DBTestBase {
+ public:
+  GlobalWriteControllerTest()
+      : DBTestBase("global_wc_test", /*env_do_fsync=*/true) {}
+
+  ~GlobalWriteControllerTest() { CloseAndDeleteDBs(); }
+
+  void OpenDBsAndSetWC(int num_dbs, Options& options) {
+    db_names_.clear();
+    for (int i = 0; i < num_dbs; i++) {
+      dbs_.push_back(nullptr);
+      db_names_.push_back(
+          test::PerThreadDBPath("db_shared_wc_db" + std::to_string(i)));
+    }
+
+    options.level0_slowdown_writes_trigger = 10;
+    options.level0_stop_writes_trigger = 20;
+    options.delayed_write_rate = 16 * MB;
+    options.use_dynamic_delay = true;
+    options.write_controller.reset(new WriteController(
+        options.use_dynamic_delay, options.delayed_write_rate));
+
+    for (int i = 0; i < num_dbs; i++) {
+      ASSERT_OK(DestroyDB(db_names_[i], options));
+      ASSERT_OK(DB::Open(options, db_names_[i], &(dbs_[i])));
+    }
+
+    dbimpls_.clear();
+    for (int i = 0; i < num_dbs; i++) {
+      dbimpls_.push_back(static_cast_with_check<DBImpl>(dbs_[i]));
+    }
+
+    cfds_.clear();
+    vstorages_.clear();
+    for (int i = 0; i < num_dbs; i++) {
+      ColumnFamilyData* cfd =
+          static_cast<ColumnFamilyHandleImpl*>(dbs_[i]->DefaultColumnFamily())
+              ->cfd();
+      cfds_.push_back(cfd);
+      vstorages_.push_back(cfd->current()->storage_info());
+    }
+
+    mutable_cf_options_ = MutableCFOptions(options);
+    destroy_options_ = options;
+  }
+
+  void CloseAndDeleteDBs() {
+    for (size_t i = 0; i < dbs_.size(); i++) {
+      ASSERT_OK(dbs_[i]->Close());
+      ASSERT_OK(DestroyDB(db_names_[i], destroy_options_));
+      delete dbs_[i];
+    }
+  }
+
+  void SetL0delayAndRecalcConditions(int db_idx, int l0_files) {
+    vstorages_[db_idx]->set_l0_delay_trigger_count(l0_files);
+    RecalculateWriteStallConditions(dbimpls_[db_idx], cfds_[db_idx],
+                                    mutable_cf_options_);
+  }
+
+  uint64_t const MB = 1024 * 1024;
+  Options destroy_options_;
+  MutableCFOptions mutable_cf_options_;
+  std::vector<std::string> db_names_;
+  std::vector<DB*> dbs_;
+  std::vector<DBImpl*> dbimpls_;
+  std::vector<ColumnFamilyData*> cfds_;
+  std::vector<VersionStorageInfo*> vstorages_;
+};
+
+// test GetMapMinRate()
+// insert different delay requests into 2 dbs
+TEST_F(GlobalWriteControllerTest, TestGetMinRate) {
+  Options options = CurrentOptions();
+  int num_dbs = 2;
+  // one set of dbs with one Write Controller(WC)
+  OpenDBsAndSetWC(num_dbs, options);
+
+  // sets db0 to 16Mbs
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 10 /*l0_files*/);
+
+  ASSERT_TRUE(options.write_controller->delayed_write_rate() == 16 * MB);
+  ASSERT_TRUE(options.write_controller->TEST_GetMapMinRate() == 16 * MB);
+
+  // sets db1 to 8Mbs
+  SetL0delayAndRecalcConditions(1 /*db_idx*/, 15 /*l0_files*/);
+
+  ASSERT_TRUE(options.write_controller->delayed_write_rate() == 8 * MB);
+  ASSERT_TRUE(options.write_controller->TEST_GetMapMinRate() == 8 * MB);
+
+  // sets db0 to 8Mbs
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 15 /*l0_files*/);
+  ASSERT_TRUE(options.write_controller->delayed_write_rate() == 8 * MB);
+  ASSERT_TRUE(options.write_controller->TEST_GetMapMinRate() == 8 * MB);
+
+  // removes delay requirement from both dbs
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 9 /*l0_files*/);
+  SetL0delayAndRecalcConditions(1 /*db_idx*/, 9 /*l0_files*/);
+  uint64_t max_rate = options.write_controller->max_delayed_write_rate();
+  ASSERT_TRUE(options.write_controller->delayed_write_rate() == max_rate);
+  ASSERT_TRUE(options.write_controller->TEST_GetMapMinRate() == max_rate);
+  ASSERT_FALSE(options.write_controller->NeedsDelay());
+}
+
+// test scenario 0:
+// make sure 2 dbs_ opened with the same write controller object also use it
+TEST_F(GlobalWriteControllerTest, SharedWriteControllerAcrossDB) {
+  Options options = CurrentOptions();
+  int num_dbs = 2;
+
+  OpenDBsAndSetWC(num_dbs, options);
+
+  ASSERT_TRUE(dbimpls_[0]->write_controller() == options.write_controller);
+  ASSERT_TRUE(dbimpls_[0]->write_controller() ==
+              dbimpls_[1]->write_controller());
+}
+
+// test scenario 1:
+// make sure 2 dbs opened with a different write controller dont use the same.
+TEST_F(GlobalWriteControllerTest, NonSharedWriteControllerAcrossDB) {
+  Options options = CurrentOptions();
+  int num_dbs = 2;
+  // one set of dbs with one Write Controller(WC)
+  OpenDBsAndSetWC(num_dbs, options);
+
+  // second db with a different WC
+  Options options2 = CurrentOptions();
+  DB* db2 = nullptr;
+  std::string db2_name = test::PerThreadDBPath("db_shared_wc_db2");
+  ASSERT_OK(DestroyDB(db2_name, options));
+  ASSERT_OK(DB::Open(options2, db2_name, &db2));
+  DBImpl* dbimpl2 = static_cast_with_check<DBImpl>(db2);
+
+  ASSERT_FALSE(dbimpl2->write_controller() == options.write_controller);
+
+  ASSERT_FALSE(dbimpls_[0]->write_controller() == dbimpl2->write_controller());
+
+  // Clean up db2.
+  ASSERT_OK(db2->Close());
+  ASSERT_OK(DestroyDB(db2_name, options2));
+  delete db2;
+}
+
+// test scenario 2:
+// setting up 2 dbs, put one into delay and check that the other is also
+// delayed. then remove the delay condition and check that they're not delayed.
+TEST_F(GlobalWriteControllerTest, SharedWriteControllerAcrossDB2) {
+  Options options = CurrentOptions();
+  int num_dbs = 2;
+  OpenDBsAndSetWC(num_dbs, options);
+
+  ASSERT_FALSE(IsDbWriteDelayed(dbimpls_[0]));
+  ASSERT_FALSE(IsDbWriteDelayed(dbimpls_[1]));
+
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 10 /*l0_files*/);
+  ASSERT_TRUE(IsDbWriteDelayed(dbimpls_[0]));
+  ASSERT_TRUE(IsDbWriteDelayed(dbimpls_[1]));
+
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 5 /*l0_files*/);
+  ASSERT_FALSE(IsDbWriteDelayed(dbimpls_[0]));
+  ASSERT_FALSE(IsDbWriteDelayed(dbimpls_[1]));
+
+  SetL0delayAndRecalcConditions(1 /*db_idx*/, 15 /*l0_files*/);
+  ASSERT_TRUE(IsDbWriteDelayed(dbimpls_[0]));
+  ASSERT_TRUE(IsDbWriteDelayed(dbimpls_[1]));
+
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 20 /*l0_files*/);
+  ASSERT_TRUE(IsDbWriteStopped(dbimpls_[0]));
+  ASSERT_TRUE(IsDbWriteStopped(dbimpls_[1]));
+
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 9 /*l0_files*/);
+  ASSERT_TRUE(IsDbWriteDelayed(dbimpls_[0]));
+  ASSERT_TRUE(IsDbWriteDelayed(dbimpls_[1]));
+
+  SetL0delayAndRecalcConditions(1 /*db_idx*/, 9 /*l0_files*/);
+  ASSERT_FALSE(IsDbWriteDelayed(dbimpls_[0]));
+  ASSERT_FALSE(IsDbWriteDelayed(dbimpls_[1]));
+}
+
+// test scenario 3:
+// setting up 2 dbs, put one into stop and check that the other is also stopped.
+// then remove the stop condition and check that they're both proceeding with
+// the writes.
+TEST_F(GlobalWriteControllerTest, SharedWriteControllerAcrossDB3) {
+  Options options = CurrentOptions();
+  int num_dbs = 2;
+  OpenDBsAndSetWC(num_dbs, options);
+
+  std::vector<port::Thread> threads;
+  int wait_count_db = 0;
+  InstrumentedMutex mutex;
+  InstrumentedCondVar cv(&mutex);
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->SetCallBack(
+      "WriteController::WaitOnCV", [&](void*) {
+        {
+          InstrumentedMutexLock lock(&mutex);
+          wait_count_db++;
+          if (wait_count_db == num_dbs) {
+            cv.Signal();
+          }
+        }
+      });
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->EnableProcessing();
+
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_FALSE(IsDbWriteDelayed(dbimpls_[i]));
+  }
+
+  // put db0 into stop state. which means db1 is also in stop state.
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 20 /*l0_files*/);
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_TRUE(IsDbWriteStopped(dbimpls_[i]));
+  }
+
+  // write to both dbs from 2 different threads.
+  bool s = true;
+  WriteOptions wo;
+
+  std::function<void(DB*)> write_db = [&](DB* db) {
+    Status tmp = db->Put(wo, "foo", "bar");
+    InstrumentedMutexLock lock(&mutex);
+    s = s && tmp.ok();
+  };
+
+  for (int i = 0; i < num_dbs; i++) {
+    threads.emplace_back(write_db, dbs_[i]);
+  }
+  // verify they are waiting on the controller cv (WriteController::WaitOnCV)
+  // use a call back with counter to make sure both threads entered the cv wait.
+  {
+    InstrumentedMutexLock lock(&mutex);
+    while (wait_count_db != num_dbs) {
+      cv.Wait();
+    }
+  }
+  // verify keys are not yet in the db as data has not yet being flushed.
+  ReadOptions ropt;
+  std::string value;
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_TRUE(dbs_[i]->Get(ropt, "foo", &value).IsNotFound());
+  }
+
+  // remove stop condition and verify write.
+  SetL0delayAndRecalcConditions(0 /*db_idx*/, 0 /*l0_files*/);
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_FALSE(IsDbWriteStopped(dbimpls_[i]));
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+  ASSERT_TRUE(s);
+
+  // get the keys.
+  for (int i = 0; i < num_dbs; i++) {
+    ASSERT_OK(dbs_[i]->Get(ropt, "foo", &value));
+    ASSERT_EQ(value, "bar");
+  }
+
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->ClearAllCallBacks();
+  ROCKSDB_NAMESPACE::SyncPoint::GetInstance()->DisableProcessing();
+}
+
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -1414,18 +1414,18 @@ bool InternalStats::HandleMinObsoleteSstNumberToKeep(uint64_t* value,
 
 bool InternalStats::HandleActualDelayedWriteRate(uint64_t* value, DBImpl* db,
                                                  Version* /*version*/) {
-  const WriteController& wc = db->write_controller();
-  if (!wc.NeedsDelay()) {
+  const WriteController* wc = db->write_controller_ptr();
+  if (!wc->NeedsDelay()) {
     *value = 0;
   } else {
-    *value = wc.delayed_write_rate();
+    *value = wc->delayed_write_rate();
   }
   return true;
 }
 
 bool InternalStats::HandleIsWriteStopped(uint64_t* value, DBImpl* db,
                                          Version* /*version*/) {
-  *value = db->write_controller().IsStopped() ? 1 : 0;
+  *value = db->write_controller()->IsStopped() ? 1 : 0;
   return true;
 }
 

--- a/db/memtable_list_test.cc
+++ b/db/memtable_list_test.cc
@@ -98,12 +98,12 @@ class MemTableListTest : public testing::Test {
     EnvOptions env_options;
     std::shared_ptr<Cache> table_cache(NewLRUCache(50000, 16));
     WriteBufferManager write_buffer_manager(db_options.db_write_buffer_size);
-    WriteController write_controller(immutable_db_options.use_dynamic_delay,
-                                     10000000u);
+    auto write_controller = std::make_shared<WriteController>(
+        immutable_db_options.use_dynamic_delay, 10000000u);
 
     VersionSet versions(dbname, &immutable_db_options, env_options,
                         table_cache.get(), &write_buffer_manager,
-                        &write_controller, /*block_cache_tracer=*/nullptr,
+                        write_controller, /*block_cache_tracer=*/nullptr,
                         /*io_tracer=*/nullptr, /*db_id*/ "",
                         /*db_session_id*/ "");
     std::vector<ColumnFamilyDescriptor> cf_descs;
@@ -150,12 +150,12 @@ class MemTableListTest : public testing::Test {
     EnvOptions env_options;
     std::shared_ptr<Cache> table_cache(NewLRUCache(50000, 16));
     WriteBufferManager write_buffer_manager(db_options.db_write_buffer_size);
-    WriteController write_controller(immutable_db_options.use_dynamic_delay,
-                                     10000000u);
+    auto write_controller = std::make_shared<WriteController>(
+        immutable_db_options.use_dynamic_delay, 10000000u);
 
     VersionSet versions(dbname, &immutable_db_options, env_options,
                         table_cache.get(), &write_buffer_manager,
-                        &write_controller, /*block_cache_tracer=*/nullptr,
+                        write_controller, /*block_cache_tracer=*/nullptr,
                         /*io_tracer=*/nullptr, /*db_id*/ "",
                         /*db_session_id*/ "");
     std::vector<ColumnFamilyDescriptor> cf_descs;

--- a/db/repair.cc
+++ b/db/repair.cc
@@ -118,9 +118,10 @@ class Repairer {
                                     /*block_cache_tracer=*/nullptr,
                                     /*io_tracer=*/nullptr, db_session_id_)),
         wb_(db_options_.db_write_buffer_size),
-        wc_(db_options_.use_dynamic_delay, db_options_.delayed_write_rate),
+        wc_(std::make_shared<WriteController>(db_options_.use_dynamic_delay,
+                                              db_options_.delayed_write_rate)),
         vset_(dbname_, &immutable_db_options_, file_options_,
-              raw_table_cache_.get(), &wb_, &wc_,
+              raw_table_cache_.get(), &wb_, wc_,
               /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
               /*db_id=*/"", db_session_id_),
         next_file_number_(1),
@@ -260,7 +261,7 @@ class Repairer {
   std::shared_ptr<Cache> raw_table_cache_;
   std::unique_ptr<TableCache> table_cache_;
   WriteBufferManager wb_;
-  WriteController wc_;
+  std::shared_ptr<WriteController> wc_;
   VersionSet vset_;
   std::unordered_map<std::string, ColumnFamilyOptions> cf_name_to_opts_;
   InstrumentedMutex mutex_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -4694,7 +4694,7 @@ VersionSet::VersionSet(const std::string& dbname,
                        const ImmutableDBOptions* _db_options,
                        const FileOptions& storage_options, Cache* table_cache,
                        WriteBufferManager* write_buffer_manager,
-                       WriteController* write_controller,
+                       std::shared_ptr<WriteController> write_controller,
                        BlockCacheTracer* const block_cache_tracer,
                        const std::shared_ptr<IOTracer>& io_tracer,
                        const std::string& db_id,
@@ -4743,7 +4743,7 @@ VersionSet::~VersionSet() {
 void VersionSet::Reset() {
   if (column_family_set_) {
     WriteBufferManager* wbm = column_family_set_->write_buffer_manager();
-    WriteController* wc = column_family_set_->write_controller();
+    auto wc = column_family_set_->write_controller();
     // db_id becomes the source of truth after DBImpl::Recover():
     // https://github.com/facebook/rocksdb/blob/v7.3.1/db/db_impl/db_impl_open.cc#L527
     // Note: we may not be able to recover db_id from MANIFEST if
@@ -5798,9 +5798,10 @@ Status VersionSet::ReduceNumberOfLevels(const std::string& dbname,
   ColumnFamilyOptions cf_options(*options);
   std::shared_ptr<Cache> tc(NewLRUCache(options->max_open_files - 10,
                                         options->table_cache_numshardbits));
-  WriteController wc(db_options.use_dynamic_delay, options->delayed_write_rate);
+  auto wc = std::make_shared<WriteController>(db_options.use_dynamic_delay,
+                                              options->delayed_write_rate);
   WriteBufferManager wb(options->db_write_buffer_size);
-  VersionSet versions(dbname, &db_options, file_options, tc.get(), &wb, &wc,
+  VersionSet versions(dbname, &db_options, file_options, tc.get(), &wb, wc,
                       nullptr /*BlockCacheTracer*/, nullptr /*IOTracer*/,
                       /*db_id*/ "",
                       /*db_session_id*/ "");
@@ -6734,7 +6735,8 @@ Status VersionSet::VerifyFileMetadata(const std::string& fpath,
 ReactiveVersionSet::ReactiveVersionSet(
     const std::string& dbname, const ImmutableDBOptions* _db_options,
     const FileOptions& _file_options, Cache* table_cache,
-    WriteBufferManager* write_buffer_manager, WriteController* write_controller,
+    WriteBufferManager* write_buffer_manager,
+    std::shared_ptr<WriteController> write_controller,
     const std::shared_ptr<IOTracer>& io_tracer)
     : VersionSet(dbname, _db_options, _file_options, table_cache,
                  write_buffer_manager, write_controller,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -1086,7 +1086,7 @@ class VersionSet {
   VersionSet(const std::string& dbname, const ImmutableDBOptions* db_options,
              const FileOptions& file_options, Cache* table_cache,
              WriteBufferManager* write_buffer_manager,
-             WriteController* write_controller,
+             std::shared_ptr<WriteController> write_controller,
              BlockCacheTracer* const block_cache_tracer,
              const std::shared_ptr<IOTracer>& io_tracer,
              const std::string& db_id, const std::string& db_session_id);
@@ -1597,7 +1597,7 @@ class ReactiveVersionSet : public VersionSet {
                      const ImmutableDBOptions* _db_options,
                      const FileOptions& _file_options, Cache* table_cache,
                      WriteBufferManager* write_buffer_manager,
-                     WriteController* write_controller,
+                     std::shared_ptr<WriteController> write_controller,
                      const std::shared_ptr<IOTracer>& io_tracer);
 
   ~ReactiveVersionSet() override;

--- a/db/version_set_test.cc
+++ b/db/version_set_test.cc
@@ -1127,7 +1127,8 @@ class VersionSetTestBase {
         immutable_options_(db_options_, cf_options_),
         mutable_cf_options_(cf_options_),
         table_cache_(NewLRUCache(50000, 16)),
-        write_controller_(db_options_.use_dynamic_delay),
+        write_controller_(
+            std::make_shared<WriteController>(db_options_.use_dynamic_delay)),
         write_buffer_manager_(db_options_.db_write_buffer_size),
         shutting_down_(false),
         mock_table_factory_(std::make_shared<mock::MockTableFactory>()) {
@@ -1150,12 +1151,12 @@ class VersionSetTestBase {
 
     versions_.reset(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     reactive_versions_ = std::make_shared<ReactiveVersionSet>(
         dbname_, &db_options_, env_options_, table_cache_.get(),
-        &write_buffer_manager_, &write_controller_, nullptr);
+        &write_buffer_manager_, write_controller_, nullptr);
     db_options_.db_paths.emplace_back(dbname_,
                                       std::numeric_limits<uint64_t>::max());
   }
@@ -1254,7 +1255,7 @@ class VersionSetTestBase {
   void ReopenDB() {
     versions_.reset(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     EXPECT_OK(versions_->Recover(column_families_, false));
@@ -1337,7 +1338,7 @@ class VersionSetTestBase {
   ImmutableOptions immutable_options_;
   MutableCFOptions mutable_cf_options_;
   std::shared_ptr<Cache> table_cache_;
-  WriteController write_controller_;
+  std::shared_ptr<WriteController> write_controller_;
   WriteBufferManager write_buffer_manager_;
   std::shared_ptr<VersionSet> versions_;
   std::shared_ptr<ReactiveVersionSet> reactive_versions_;
@@ -1760,7 +1761,7 @@ TEST_F(VersionSetTest, WalAddition) {
   {
     std::unique_ptr<VersionSet> new_versions(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     ASSERT_OK(new_versions->Recover(column_families_, /*read_only=*/false));
@@ -1827,7 +1828,7 @@ TEST_F(VersionSetTest, WalCloseWithoutSync) {
   {
     std::unique_ptr<VersionSet> new_versions(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     ASSERT_OK(new_versions->Recover(column_families_, false));
@@ -1880,7 +1881,7 @@ TEST_F(VersionSetTest, WalDeletion) {
   {
     std::unique_ptr<VersionSet> new_versions(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     ASSERT_OK(new_versions->Recover(column_families_, false));
@@ -1918,7 +1919,7 @@ TEST_F(VersionSetTest, WalDeletion) {
   {
     std::unique_ptr<VersionSet> new_versions(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     ASSERT_OK(new_versions->Recover(column_families_, false));
@@ -2038,7 +2039,7 @@ TEST_F(VersionSetTest, DeleteWalsBeforeNonExistingWalNumber) {
   {
     std::unique_ptr<VersionSet> new_versions(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     ASSERT_OK(new_versions->Recover(column_families_, false));
@@ -2074,7 +2075,7 @@ TEST_F(VersionSetTest, DeleteAllWals) {
   {
     std::unique_ptr<VersionSet> new_versions(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     ASSERT_OK(new_versions->Recover(column_families_, false));
@@ -2116,7 +2117,7 @@ TEST_F(VersionSetTest, AtomicGroupWithWalEdits) {
   {
     std::unique_ptr<VersionSet> new_versions(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     std::string db_id;
@@ -2170,7 +2171,7 @@ class VersionSetWithTimestampTest : public VersionSetTest {
   void VerifyFullHistoryTsLow(uint64_t expected_ts_low) {
     std::unique_ptr<VersionSet> vset(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
     ASSERT_OK(vset->Recover(column_families_, /*read_only=*/false,

--- a/db/version_util.h
+++ b/db/version_util.h
@@ -18,12 +18,13 @@ namespace ROCKSDB_NAMESPACE {
 class OfflineManifestWriter {
  public:
   OfflineManifestWriter(const DBOptions& options, const std::string& db_path)
-      : wc_(options.use_dynamic_delay, options.delayed_write_rate),
+      : wc_(std::make_shared<WriteController>(options.use_dynamic_delay,
+                                              options.delayed_write_rate)),
         wb_(options.db_write_buffer_size),
         immutable_db_options_(WithDbPath(options, db_path)),
         tc_(NewLRUCache(1 << 20 /* capacity */,
                         options.table_cache_numshardbits)),
-        versions_(db_path, &immutable_db_options_, sopt_, tc_.get(), &wb_, &wc_,
+        versions_(db_path, &immutable_db_options_, sopt_, tc_.get(), &wb_, wc_,
                   /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                   /*db_id*/ "", /*db_session_id*/ "") {}
 
@@ -47,7 +48,7 @@ class OfflineManifestWriter {
   const ImmutableDBOptions& IOptions() { return immutable_db_options_; }
 
  private:
-  WriteController wc_;
+  std::shared_ptr<WriteController> wc_;
   WriteBufferManager wb_;
   ImmutableDBOptions immutable_db_options_;
   std::shared_ptr<Cache> tc_;

--- a/db/wal_manager_test.cc
+++ b/db/wal_manager_test.cc
@@ -34,7 +34,8 @@ class WalManagerTest : public testing::Test {
   WalManagerTest()
       : dbname_(test::PerThreadDBPath("wal_manager_test")),
         db_options_(),
-        write_controller_(db_options_.use_dynamic_delay),
+        write_controller_(
+            std::make_shared<WriteController>(db_options_.use_dynamic_delay)),
         table_cache_(NewLRUCache(50000, 16)),
         write_buffer_manager_(db_options_.db_write_buffer_size),
         current_log_number_(0) {
@@ -54,7 +55,7 @@ class WalManagerTest : public testing::Test {
 
     versions_.reset(
         new VersionSet(dbname_, &db_options_, env_options_, table_cache_.get(),
-                       &write_buffer_manager_, &write_controller_,
+                       &write_buffer_manager_, write_controller_,
                        /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                        /*db_id*/ "", /*db_session_id*/ ""));
 
@@ -113,7 +114,7 @@ class WalManagerTest : public testing::Test {
   std::unique_ptr<MockEnv> env_;
   std::string dbname_;
   ImmutableDBOptions db_options_;
-  WriteController write_controller_;
+  std::shared_ptr<WriteController> write_controller_;
   EnvOptions env_options_;
   std::shared_ptr<Cache> table_cache_;
   WriteBufferManager write_buffer_manager_;

--- a/db/write_controller.cc
+++ b/db/write_controller.cc
@@ -8,9 +8,11 @@
 #include <algorithm>
 #include <atomic>
 #include <cassert>
+#include <mutex>
 #include <ratio>
 
 #include "rocksdb/system_clock.h"
+#include "test_util/sync_point.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -21,16 +23,95 @@ std::unique_ptr<WriteControllerToken> WriteController::GetStopToken() {
 
 std::unique_ptr<WriteControllerToken> WriteController::GetDelayToken(
     uint64_t write_rate) {
-  if (0 == total_delayed_++) {
-    // Starting delay, so reset counters.
-    next_refill_time_ = 0;
-    credit_in_bytes_ = 0;
+  {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (0 == total_delayed_++) {
+      // Starting delay, so reset counters.
+      next_refill_time_ = 0;
+      credit_in_bytes_ = 0;
+    }
   }
   // NOTE: for simplicity, any current credit_in_bytes_ or "debt" in
   // next_refill_time_ will be based on an old rate. This rate will apply
   // for subsequent additional debts and for the next refill.
   set_delayed_write_rate(write_rate);
   return std::unique_ptr<WriteControllerToken>(new DelayWriteToken(this));
+}
+
+uint64_t WriteController::TEST_GetMapMinRate() { return GetMapMinRate(); }
+
+void WriteController::AddToDbRateMap(CfIdToRateMap* cf_map) {
+  std::lock_guard<std::mutex> lock(mu_for_map_);
+  db_id_to_write_rate_map_.insert(cf_map);
+}
+
+void WriteController::RemoveFromDbRateMap(CfIdToRateMap* cf_map) {
+  std::lock_guard<std::mutex> lock(mu_for_map_);
+  db_id_to_write_rate_map_.erase(cf_map);
+}
+
+// REQUIRES: write_controller map mutex held.
+uint64_t WriteController::GetMapMinRate() {
+  uint64_t min_rate = max_delayed_write_rate();
+  for (auto cf_id_to_write_rate_ : db_id_to_write_rate_map_) {
+    for (const auto& key_val : *cf_id_to_write_rate_) {
+      if (key_val.second < min_rate) {
+        min_rate = key_val.second;
+      }
+    }
+  }
+  return min_rate;
+}
+
+bool WriteController::IsMinRate(uint32_t id, CfIdToRateMap* cf_map) {
+  if (!cf_map->count(id)) {
+    return false;
+  }
+  uint64_t min_rate = delayed_write_rate();
+  auto cf_rate = (*cf_map)[id];
+  // the cf is already in the map so it shouldnt be possible for it to have a
+  // lower rate than the delayed_write_rate_ unless set_max_delayed_write_rate
+  // has been used which also sets delayed_write_rate_
+  // its fine for several cfs to have the same min_rate.
+  return cf_rate <= min_rate;
+}
+
+void WriteController::DeleteSelfFromMapAndMaybeUpdateDelayRate(
+    uint32_t id, CfIdToRateMap* cf_map) {
+  std::lock_guard<std::mutex> lock(mu_for_map_);
+  bool was_min = IsMinRate(id, cf_map);
+  cf_map->erase(id);
+  if (was_min) {
+    set_delayed_write_rate(GetMapMinRate());
+  }
+}
+
+// the usual case is to set the write_rate of this cf only if its lower than the
+// current min (delayed_write_rate_) but theres also the case where this cf was
+// the min rate (was_min) and now its write_rate is higher than the
+// delayed_write_rate_ so we need to find a new min from all cfs
+// (GetMapMinRate())
+uint64_t WriteController::InsertToMapAndGetMinRate(uint32_t id,
+                                                   CfIdToRateMap* cf_map,
+                                                   uint64_t cf_write_rate) {
+  std::lock_guard<std::mutex> lock(mu_for_map_);
+  bool was_min = IsMinRate(id, cf_map);
+  cf_map->insert_or_assign(id, cf_write_rate);
+  if (cf_write_rate <= delayed_write_rate()) {
+    return cf_write_rate;
+  } else if (was_min) {
+    return GetMapMinRate();
+  } else {
+    return delayed_write_rate();
+  }
+}
+
+void WriteController::WaitOnCV(const ErrorHandler& error_handler) {
+  std::unique_lock<std::mutex> lock(stop_mutex_);
+  while (error_handler.GetBGError().ok() && IsStopped()) {
+    TEST_SYNC_POINT("WriteController::WaitOnCV");
+    stop_cv_.wait(lock);
+  }
 }
 
 std::unique_ptr<WriteControllerToken>
@@ -43,10 +124,8 @@ WriteController::GetCompactionPressureToken() {
 bool WriteController::IsStopped() const {
   return total_stopped_.load(std::memory_order_relaxed) > 0;
 }
-// This is inside DB mutex, so we can't sleep and need to minimize
-// frequency to get time.
-// If it turns out to be a performance issue, we can redesign the thread
-// synchronization model here.
+
+// This function is no longer under db mutex since credit_in_bytes_ is atomic
 // The function trust caller will sleep micros returned.
 uint64_t WriteController::GetDelay(SystemClock* clock, uint64_t num_bytes) {
   if (total_stopped_.load(std::memory_order_relaxed) > 0) {
@@ -56,9 +135,10 @@ uint64_t WriteController::GetDelay(SystemClock* clock, uint64_t num_bytes) {
     return 0;
   }
 
-  if (credit_in_bytes_ >= num_bytes) {
-    credit_in_bytes_ -= num_bytes;
-    return 0;
+  auto credits = credit_in_bytes_.load();
+  while (credits >= num_bytes) {
+    if (credit_in_bytes_.compare_exchange_weak(credits, credits - num_bytes))
+      return 0;
   }
   // The frequency to get time inside DB mutex is less than one per refill
   // interval.
@@ -67,6 +147,8 @@ uint64_t WriteController::GetDelay(SystemClock* clock, uint64_t num_bytes) {
   const uint64_t kMicrosPerSecond = 1000000;
   // Refill every 1 ms
   const uint64_t kMicrosPerRefill = 1000;
+
+  std::lock_guard<std::mutex> lock(mu_);
 
   if (next_refill_time_ == 0) {
     // Start with an initial allotment of bytes for one interval
@@ -103,10 +185,16 @@ uint64_t WriteController::NowMicrosMonotonic(SystemClock* clock) {
   return clock->NowNanos() / std::milli::den;
 }
 
-StopWriteToken::~StopWriteToken() {
-  assert(controller_->total_stopped_ >= 1);
-  --controller_->total_stopped_;
+void WriteController::NotifyCV() {
+  assert(total_stopped_ >= 1);
+  {
+    std::lock_guard<std::mutex> lock(stop_mutex_);
+    --total_stopped_;
+  }
+  stop_cv_.notify_all();
 }
+
+StopWriteToken::~StopWriteToken() { controller_->NotifyCV(); }
 
 DelayWriteToken::~DelayWriteToken() {
   controller_->total_delayed_--;

--- a/db/write_controller.h
+++ b/db/write_controller.h
@@ -8,7 +8,11 @@
 #include <stdint.h>
 
 #include <atomic>
+#include <condition_variable>
 #include <memory>
+#include <mutex>
+
+#include "db/error_handler.h"
 #include "rocksdb/rate_limiter.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -23,7 +27,7 @@ class WriteControllerToken;
 class WriteController {
  public:
   explicit WriteController(bool dynamic_delay,
-                           uint64_t _delayed_write_rate = 1024u * 1024u * 32u,
+                           uint64_t _delayed_write_rate = 1024u * 1024u * 16u,
                            int64_t low_pri_rate_bytes_per_sec = 1024 * 1024)
       : total_stopped_(0),
         total_delayed_(0),
@@ -88,7 +92,31 @@ class WriteController {
 
   bool is_dynamic_delay() const { return dynamic_delay_; }
 
+  std::mutex& GetMapMutex() { return mu_for_map_; }
+
+  using CfIdToRateMap = std::unordered_map<uint32_t, uint64_t>;
+
+  void AddToDbRateMap(CfIdToRateMap* cf_map);
+
+  void RemoveFromDbRateMap(CfIdToRateMap* cf_map);
+
+  void DeleteSelfFromMapAndMaybeUpdateDelayRate(uint32_t id,
+                                                CfIdToRateMap* cf_map);
+
+  uint64_t InsertToMapAndGetMinRate(uint32_t id, CfIdToRateMap* cf_map,
+                                    uint64_t cf_write_rate);
+
+  uint64_t TEST_GetMapMinRate();
+
+  void WaitOnCV(const ErrorHandler& error_handler);
+  void NotifyCV();
+
  private:
+  bool IsMinRate(uint32_t id, CfIdToRateMap* cf_map);
+
+  // returns the min rate from db_id_to_write_rate_map_
+  uint64_t GetMapMinRate();
+
   uint64_t NowMicrosMonotonic(SystemClock* clock);
 
   friend class WriteControllerToken;
@@ -100,16 +128,26 @@ class WriteController {
   std::atomic<int> total_delayed_;
   std::atomic<int> total_compaction_pressure_;
 
+  // mutex to protect below 4 members
+  std::mutex mu_;
   // Number of bytes allowed to write without delay
-  uint64_t credit_in_bytes_;
+  std::atomic<uint64_t> credit_in_bytes_;
   // Next time that we can add more credit of bytes
-  uint64_t next_refill_time_;
+  std::atomic<uint64_t> next_refill_time_;
   // Write rate set when initialization or by `DBImpl::SetDBOptions`
-  uint64_t max_delayed_write_rate_;
+  std::atomic<uint64_t> max_delayed_write_rate_;
   // Current write rate (bytes / second)
-  uint64_t delayed_write_rate_;
+  std::atomic<uint64_t> delayed_write_rate_;
+
   // Whether Speedb's dynamic delay is used
   bool dynamic_delay_;
+
+  std::mutex mu_for_map_;
+  std::unordered_set<CfIdToRateMap*> db_id_to_write_rate_map_;
+
+  std::condition_variable stop_cv_;
+  // The mutex used by stop_cv_
+  std::mutex stop_mutex_;
 
   std::unique_ptr<RateLimiter> low_pri_rate_limiter_;
 };

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -56,6 +56,7 @@ class Statistics;
 class InternalKeyComparator;
 class WalFilter;
 class FileSystem;
+class WriteController;
 
 struct Options;
 struct DbPath;
@@ -920,6 +921,15 @@ struct DBOptions {
   //
   // Default: null
   std::shared_ptr<WriteBufferManager> write_buffer_manager = nullptr;
+
+  // This object tracks and enforces the delay requirements of all cfs in all
+  // the dbs where its passed
+  //
+  // Only supported together with use_dynamic_delay. passing a WriteController
+  // here forces use_dynamic_delay.
+  //
+  // Default: null
+  std::shared_ptr<WriteController> write_controller = nullptr;
 
   // Specify the file access pattern once a compaction is started.
   // It will be applied to all input files of a compaction.

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -728,6 +728,7 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       advise_random_on_open(options.advise_random_on_open),
       db_write_buffer_size(options.db_write_buffer_size),
       write_buffer_manager(options.write_buffer_manager),
+      write_controller(options.write_controller),
       access_hint_on_compaction_start(options.access_hint_on_compaction_start),
       random_access_max_buffer_size(options.random_access_max_buffer_size),
       use_adaptive_mutex(options.use_adaptive_mutex),
@@ -859,6 +860,8 @@ void ImmutableDBOptions::Dump(Logger* log) const {
                    advise_random_on_open);
   ROCKS_LOG_HEADER(log, "                      Options.use_dynamic_delay: %d",
                    use_dynamic_delay);
+  ROCKS_LOG_HEADER(log, "                   Options.write_controller: %p",
+                   write_controller.get());
   ROCKS_LOG_HEADER(
       log, "                   Options.db_write_buffer_size: %" ROCKSDB_PRIszt,
       db_write_buffer_size);

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -60,6 +60,7 @@ struct ImmutableDBOptions {
   bool advise_random_on_open;
   size_t db_write_buffer_size;
   std::shared_ptr<WriteBufferManager> write_buffer_manager;
+  std::shared_ptr<WriteController> write_controller;
   DBOptions::AccessHint access_hint_on_compaction_start;
   size_t random_access_max_buffer_size;
   bool use_adaptive_mutex;

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -123,6 +123,7 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.advise_random_on_open = immutable_db_options.advise_random_on_open;
   options.db_write_buffer_size = immutable_db_options.db_write_buffer_size;
   options.write_buffer_manager = immutable_db_options.write_buffer_manager;
+  options.write_controller = immutable_db_options.write_controller;
   options.access_hint_on_compaction_start =
       immutable_db_options.access_hint_on_compaction_start;
   options.compaction_readahead_size =

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -240,6 +240,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
       {offsetof(struct DBOptions, wal_dir), sizeof(std::string)},
       {offsetof(struct DBOptions, write_buffer_manager),
        sizeof(std::shared_ptr<WriteBufferManager>)},
+      {offsetof(struct DBOptions, write_controller),
+       sizeof(std::shared_ptr<WriteController>)},
       {offsetof(struct DBOptions, listeners),
        sizeof(std::vector<std::shared_ptr<EventListener>>)},
       {offsetof(struct DBOptions, row_cache), sizeof(std::shared_ptr<Cache>)},

--- a/src.mk
+++ b/src.mk
@@ -521,6 +521,7 @@ TEST_MAIN_SOURCES =                                                     \
   db/write_batch_test.cc                                                \
   db/write_callback_test.cc                                             \
   db/write_controller_test.cc                                           \
+  db/global_write_controller_test.cc                                    \
   env/env_basic_test.cc                                                 \
   env/env_test.cc                                                       \
   env/io_posix_test.cc                                                  \

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -5020,6 +5020,14 @@ class Benchmark {
           FLAGS_initiate_wbm_flushes, flush_initiation_options));
     }
 
+    if (FLAGS_use_dynamic_delay && FLAGS_num_multi_db > 1) {
+      if (options.delayed_write_rate <= 0) {
+        options.delayed_write_rate = 16 * 1024 * 1024;
+      }
+      options.write_controller.reset(new WriteController(
+          options.use_dynamic_delay, options.delayed_write_rate));
+    }
+
     // Integrated BlobDB
     options.enable_blob_files = FLAGS_enable_blob_files;
     options.min_blob_size = FLAGS_min_blob_size;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1322,10 +1322,11 @@ void DumpManifestFile(Options options, std::string file, bool verbose, bool hex,
   // SanitizeOptions(), we need to initialize it manually.
   options.db_paths.emplace_back("dummy", 0);
   options.num_levels = 64;
-  WriteController wc(options.use_dynamic_delay, options.delayed_write_rate);
+  auto wc = std::make_shared<WriteController>(options.use_dynamic_delay,
+                                              options.delayed_write_rate);
   WriteBufferManager wb(options.db_write_buffer_size);
   ImmutableDBOptions immutable_db_options(options);
-  VersionSet versions(dbname, &immutable_db_options, sopt, tc.get(), &wb, &wc,
+  VersionSet versions(dbname, &immutable_db_options, sopt, tc.get(), &wb, wc,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                       /*db_id*/ "", /*db_session_id*/ "");
   Status s = versions.DumpManifest(options, file, verbose, hex, json);
@@ -1464,10 +1465,11 @@ Status GetLiveFilesChecksumInfoFromVersionSet(Options options,
   // SanitizeOptions(), we need to initialize it manually.
   options.db_paths.emplace_back(db_path, 0);
   options.num_levels = 64;
-  WriteController wc(options.use_dynamic_delay, options.delayed_write_rate);
+  auto wc = std::make_shared<WriteController>(options.use_dynamic_delay,
+                                              options.delayed_write_rate);
   WriteBufferManager wb(options.db_write_buffer_size);
   ImmutableDBOptions immutable_db_options(options);
-  VersionSet versions(dbname, &immutable_db_options, sopt, tc.get(), &wb, &wc,
+  VersionSet versions(dbname, &immutable_db_options, sopt, tc.get(), &wb, wc,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                       /*db_id*/ "", /*db_session_id*/ "");
   std::vector<std::string> cf_name_list;
@@ -2272,9 +2274,10 @@ Status ReduceDBLevelsCommand::GetOldNumOfLevels(Options& opt,
   std::shared_ptr<Cache> tc(
       NewLRUCache(opt.max_open_files - 10, opt.table_cache_numshardbits));
   const InternalKeyComparator cmp(opt.comparator);
-  WriteController wc(opt.use_dynamic_delay, opt.delayed_write_rate);
+  auto wc = std::make_shared<WriteController>(opt.use_dynamic_delay,
+                                              opt.delayed_write_rate);
   WriteBufferManager wb(opt.db_write_buffer_size);
-  VersionSet versions(db_path_, &db_options, soptions, tc.get(), &wb, &wc,
+  VersionSet versions(db_path_, &db_options, soptions, tc.get(), &wb, wc,
                       /*block_cache_tracer=*/nullptr, /*io_tracer=*/nullptr,
                       /*db_id*/ "", /*db_session_id*/ "");
   std::vector<ColumnFamilyDescriptor> dummy;

--- a/tools/ldb_cmd_test.cc
+++ b/tools/ldb_cmd_test.cc
@@ -204,11 +204,12 @@ class FileChecksumTestHelper {
                                           options_.table_cache_numshardbits));
     options_.db_paths.emplace_back(dbname_, 0);
     options_.num_levels = 64;
-    WriteController wc(options_.use_dynamic_delay, options_.delayed_write_rate);
+    auto wc = std::make_shared<WriteController>(options_.use_dynamic_delay,
+                                                options_.delayed_write_rate);
     WriteBufferManager wb(options_.db_write_buffer_size);
     ImmutableDBOptions immutable_db_options(options_);
-    VersionSet versions(dbname_, &immutable_db_options, sopt, tc.get(), &wb,
-                        &wc, nullptr, nullptr, "", "");
+    VersionSet versions(dbname_, &immutable_db_options, sopt, tc.get(), &wb, wc,
+                        nullptr, nullptr, "", "");
     std::vector<std::string> cf_name_list;
     Status s;
     s = versions.ListColumnFamilies(&cf_name_list, dbname_,


### PR DESCRIPTION
Write Controller is now a shared_ptr option in ImmutableDBOptions which keeps track and enforces all the delay requirements of the cfs in the dbs that those options were passed to. 
closes #346 