### PR TITLE
Enforce writing licenses inside a source file

### DIFF
--- a/build_tools/check-sources.sh
+++ b/build_tools/check-sources.sh
@@ -43,6 +43,12 @@ if [ "$?" != "1" ]; then
   BAD=1
 fi
 
+git grep -Li -E "license|copyright" -- ':*speed*.cc' ':*spdb*.h' ':*speed*.h' ':*spdb*.cc'
+if [ "$?" != "1" ]; then
+  echo '^^^^ Source files do not contain license'
+  BAD=1
+fi
+
 if [ "$BAD" ]; then
   exit 1
 fi


### PR DESCRIPTION
Some files did not have license, added to the source file check that all speedb new source files will contain license