### PR TITLE
Global delay bug fix: check again credits under mutex

### DIFF
--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -898,7 +898,6 @@ int GetL0ThresholdSpeedupCompaction(int level0_file_num_compaction_trigger,
 namespace {
 const uint64_t Gb = 1ull << 30;
 const uint64_t Mb = 1ull << 20;
-const uint64_t kMinWriteRate = 16 * 1024u;  // Minimum write rate 16KB/s.
 const int kMemtablePenalty = 10;
 }  // namespace
 
@@ -925,8 +924,8 @@ std::unique_ptr<WriteControllerToken> ColumnFamilyData::DynamicSetupDelay(
           compaction_needed_bytes, mutable_cf_options, write_stall_cause);
   assert(rate_divider >= 1);
   auto write_rate = static_cast<uint64_t>(max_write_rate / rate_divider);
-  if (write_rate < kMinWriteRate) {
-    write_rate = kMinWriteRate;
+  if (write_rate < WriteController::kMinWriteRate) {
+    write_rate = WriteController::kMinWriteRate;
   }
 
   // GetDelayToken returns a DelayWriteToken and also sets the


### PR DESCRIPTION
i encountered a bug while running tests for the dirty memory connection to the global write controller and the bug is as follows:
during WriteController::GetDelay , we check if there are enough credits and return if there are, here:
```
auto credits = credit_in_bytes_.load();
  while (credits >= num_bytes) {
    if (credit_in_bytes_.compare_exchange_weak(credits, credits - num_bytes))
      return 0;
 }
```
if there arent enough credits, we proceed under the mutex but dont check again the condition above which might have changed from a different thread. 
this PR adds this additional check and while at it, rename and reorder some members.