### PR TITLE
Set initiate_wbm_flushes to the same default value used by the WBM (true) (#480)

### DIFF
--- a/db_stress_tool/db_stress_gflags.cc
+++ b/db_stress_tool/db_stress_gflags.cc
@@ -139,7 +139,8 @@ DEFINE_uint64(db_write_buffer_size,
 
 DEFINE_bool(allow_wbm_stalls, false, "Enable WBM write stalls and delays");
 
-DEFINE_bool(initiate_wbm_flushes, false,
+DEFINE_bool(initiate_wbm_flushes,
+            ROCKSDB_NAMESPACE::WriteBufferManager::kDfltInitiateFlushes,
             "WBM will proactively initiate flushes (Speedb)."
             "If false, WBM-related flushes will be initiated using the "
             "ShouldFlush() service "

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3095,7 +3095,9 @@ void InitializeOptionsFromFlags(
   block_based_options.num_file_reads_for_auto_readahead =
       FLAGS_num_file_reads_for_auto_readahead;
   options.table_factory.reset(NewBlockBasedTableFactory(block_based_options));
-  if (FLAGS_db_write_buffer_size > 0) {
+  if (FLAGS_db_write_buffer_size > 0 ||
+      (FLAGS_initiate_wbm_flushes !=
+       ROCKSDB_NAMESPACE::WriteBufferManager::kDfltInitiateFlushes)) {
     WriteBufferManager::FlushInitiationOptions flush_initiation_options;
     if (FLAGS_max_num_parallel_flushes > 0U) {
       flush_initiation_options.max_num_parallel_flushes =

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -3095,18 +3095,19 @@ void InitializeOptionsFromFlags(
   block_based_options.num_file_reads_for_auto_readahead =
       FLAGS_num_file_reads_for_auto_readahead;
   options.table_factory.reset(NewBlockBasedTableFactory(block_based_options));
-  if (FLAGS_db_write_buffer_size > 0 ||
-      (FLAGS_initiate_wbm_flushes !=
-       ROCKSDB_NAMESPACE::WriteBufferManager::kDfltInitiateFlushes)) {
-    WriteBufferManager::FlushInitiationOptions flush_initiation_options;
-    if (FLAGS_max_num_parallel_flushes > 0U) {
-      flush_initiation_options.max_num_parallel_flushes =
-          FLAGS_max_num_parallel_flushes;
-    }
-    options.write_buffer_manager.reset(new WriteBufferManager(
-        FLAGS_db_write_buffer_size, {} /* cache */, FLAGS_allow_wbm_stalls,
-        FLAGS_initiate_wbm_flushes, flush_initiation_options));
+
+  // Write-Buffer-Manager
+  WriteBufferManager::FlushInitiationOptions flush_initiation_options;
+  if (FLAGS_max_num_parallel_flushes > 0U) {
+    flush_initiation_options.max_num_parallel_flushes =
+        FLAGS_max_num_parallel_flushes;
   }
+  // Unlike db-bench, db_stress currently has no cost-to-cache flag
+  // (see https://github.com/speedb-io/speedb/issues/512)
+  options.write_buffer_manager.reset(new WriteBufferManager(
+      FLAGS_db_write_buffer_size, {} /* cache */, FLAGS_allow_wbm_stalls,
+      FLAGS_initiate_wbm_flushes, flush_initiation_options));
+
   options.write_buffer_size = FLAGS_write_buffer_size;
   options.max_write_buffer_number = FLAGS_max_write_buffer_number;
   options.min_write_buffer_number_to_merge =

--- a/db_stress_tool/db_stress_tool.cc
+++ b/db_stress_tool/db_stress_tool.cc
@@ -355,21 +355,6 @@ int db_stress_tool(int argc, char** argv) {
                                      keys_per_level * (levels - 1));
   }
   std::unique_ptr<ROCKSDB_NAMESPACE::SharedState> shared;
-
-  if (FLAGS_db_write_buffer_size == 0) {
-    if (FLAGS_allow_wbm_stalls) {
-      fprintf(stderr,
-              "-allow_wbm_stalls is useless if db_write_buffer_size == 0\n");
-      exit(1);
-    }
-    if (FLAGS_initiate_wbm_flushes) {
-      fprintf(
-          stderr,
-          "-initiate_wbm_flushes is useless if db_write_buffer_size == 0\n");
-      exit(1);
-    }
-  }
-
   std::unique_ptr<ROCKSDB_NAMESPACE::StressTest> stress;
   if (FLAGS_test_cf_consistency) {
     stress.reset(CreateCfConsistencyStressTest());

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4916,16 +4916,9 @@ class Benchmark {
     options.track_and_verify_wals_in_manifest =
         FLAGS_track_and_verify_wals_in_manifest;
 
-    if (FLAGS_db_write_buffer_size == 0) {
-      if (FLAGS_allow_wbm_stalls) {
-        ErrorExit("-allow_wbm_stalls is useless if db_write_buffer_size == 0");
-      }
-      if (FLAGS_initiate_wbm_flushes) {
-        ErrorExit(
-            "-initiate_wbm_flushes is useless if db_write_buffer_size == 0");
-      }
-    }
-    if (FLAGS_cost_write_buffer_to_cache || FLAGS_db_write_buffer_size != 0) {
+    if (FLAGS_cost_write_buffer_to_cache || FLAGS_db_write_buffer_size != 0 ||
+        (FLAGS_initiate_wbm_flushes !=
+         ROCKSDB_NAMESPACE::WriteBufferManager::kDfltInitiateFlushes)) {
       WriteBufferManager::FlushInitiationOptions flush_initiation_options;
       if (FLAGS_max_num_parallel_flushes > 0U) {
         flush_initiation_options.max_num_parallel_flushes =

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -4916,17 +4916,19 @@ class Benchmark {
     options.track_and_verify_wals_in_manifest =
         FLAGS_track_and_verify_wals_in_manifest;
 
-    if (FLAGS_cost_write_buffer_to_cache || FLAGS_db_write_buffer_size != 0 ||
-        (FLAGS_initiate_wbm_flushes !=
-         ROCKSDB_NAMESPACE::WriteBufferManager::kDfltInitiateFlushes)) {
-      WriteBufferManager::FlushInitiationOptions flush_initiation_options;
-      if (FLAGS_max_num_parallel_flushes > 0U) {
-        flush_initiation_options.max_num_parallel_flushes =
-            FLAGS_max_num_parallel_flushes;
-      }
-
+    // Write-Buffer-Manager
+    WriteBufferManager::FlushInitiationOptions flush_initiation_options;
+    if (FLAGS_max_num_parallel_flushes > 0U) {
+      flush_initiation_options.max_num_parallel_flushes =
+          FLAGS_max_num_parallel_flushes;
+    }
+    if (FLAGS_cost_write_buffer_to_cache) {
       options.write_buffer_manager.reset(new WriteBufferManager(
           FLAGS_db_write_buffer_size, cache_, FLAGS_allow_wbm_stalls,
+          FLAGS_initiate_wbm_flushes, flush_initiation_options));
+    } else {
+      options.write_buffer_manager.reset(new WriteBufferManager(
+          FLAGS_db_write_buffer_size, {} /* cache */, FLAGS_allow_wbm_stalls,
           FLAGS_initiate_wbm_flushes, flush_initiation_options));
     }
 

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -543,7 +543,8 @@ DEFINE_bool(cost_write_buffer_to_cache, false,
 
 DEFINE_bool(allow_wbm_stalls, false, "Enable WBM write stalls and delays");
 
-DEFINE_bool(initiate_wbm_flushes, false,
+DEFINE_bool(initiate_wbm_flushes,
+            ROCKSDB_NAMESPACE::WriteBufferManager::kDfltInitiateFlushes,
             "WBM will proactively initiate flushes (Speedb)."
             "If false, WBM-related flushes will be initiated using the "
             "ShouldFlush() service "

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -763,10 +763,6 @@ def finalize_and_sanitize(src_params, counter):
         dest_params["bloom_bits"] = random.choice([random.randint(1,19),
                                          random.lognormvariate(2.3, 1.3)])
 
-    # If initiate_wbm_flushes is enabled, db_write_buffer_size must be > 0, otherwise db_stress crashes 
-    if dest_params.get("initiate_wbm_flushes") == 1:
-      dest_params["db_write_buffer_size"]= random.choice([1024 * 1024, 8 * 1024 * 1024, 128 * 1024 * 1024, 1024 * 1024 * 1024])
-
     return dest_params
 
 


### PR DESCRIPTION
Please note that now the user of db_bench / db_stress must either override the default of initiate_wbm_flushes to false or leave it true, but set the db_write_buffer_size flag to a value > 0 