### PR TITLE
Transaction test unlock wal fix

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,5 @@
 # Speedb Change Log 
-
+* fix UnlockWALStallCleared test in utilities/transactions/transaction_test.cc (#514)
 ## Blueberry 2.1.0 (10/26/2022)
 ## New Features
 * Added new Paired bloom filter that reduces false positive rate with the same performance and memory. In some configurations, the memory consumption is even reduced by up to 30%.


### PR DESCRIPTION
closes #493 

When external_delay = true, a stop token is taken in addition to the LockWal stop token. when UnlockWal() is called, it releases the stop token and calls bg_cv_.SignalAll() . this wakes a sleeping writing thread to call EndWriteStall() which in turn increments stall_ended_count_. stall_ended_count_ is the counter that the UnlockWal() thread is waiting on in WaitForStallEndedCount. this is where our current code is stuck since during https://github.com/speedb-io/speedb/issues/346 , we've moved the waiting to a cv in the WriteController and not in the DB since there can be many dbs sharing a WriteController. The thread in UnlockWal() is stuck since when the writing thread wakes up (after detor of Stop Token), it does not call EndWriteStall() but simply stays in the while loop since the IsStopped condition is still true (the external_delay token).
looking at the code of UnlockWal, it doesnt seem viable to release the UnlockWal() thread when theres still an active stop token which is what the current test is doing.

fix by:
release the external stop token taken before calling UnlockWal() so that both the stop conditions will be removed when UnlockWal() checks WaitForStallEndedCount.