### PR TITLE
WIP: Allow Serialization of only options that have changed

### DIFF
--- a/env/composite_env_wrapper.h
+++ b/env/composite_env_wrapper.h
@@ -289,8 +289,9 @@ class CompositeEnvWrapper : public CompositeEnv {
   const Customizable* Inner() const override { return target_.env; }
 
   Status PrepareOptions(const ConfigOptions& options) override;
-  std::string SerializeOptions(const ConfigOptions& config_options,
-                               const std::string& header) const override;
+  Status SerializeOptions(
+      const ConfigOptions& config_options,
+      std::unordered_map<std::string, std::string>* options) const override;
 
   // Return the target to which this Env forwards all calls
   Env* env_target() const { return target_.env; }

--- a/env/file_system.cc
+++ b/env/file_system.cc
@@ -226,7 +226,7 @@ IOStatus ReadFileToString(FileSystem* fs, const std::string& fname,
 
 namespace {
 static std::unordered_map<std::string, OptionTypeInfo> fs_wrapper_type_info = {
-    {"target",
+    {Customizable::kTargetPropName(),
      OptionTypeInfo::AsCustomSharedPtr<FileSystem>(
          0, OptionVerificationType::kByName, OptionTypeFlags::kDontSerialize)},
 };
@@ -243,24 +243,14 @@ Status FileSystemWrapper::PrepareOptions(const ConfigOptions& options) {
   return FileSystem::PrepareOptions(options);
 }
 
-std::string FileSystemWrapper::SerializeOptions(
-    const ConfigOptions& config_options, const std::string& header) const {
-  auto parent = FileSystem::SerializeOptions(config_options, "");
-  if (config_options.IsShallow() || target_ == nullptr ||
-      target_->IsInstanceOf(FileSystem::kDefaultName())) {
-    return parent;
-  } else {
-    std::string result = header;
-    if (!StartsWith(parent, OptionTypeInfo::kIdPropName())) {
-      result.append(OptionTypeInfo::kIdPropName()).append("=");
-    }
-    result.append(parent);
-    if (!EndsWith(result, config_options.delimiter)) {
-      result.append(config_options.delimiter);
-    }
-    result.append("target=").append(target_->ToString(config_options));
-    return result;
+Status FileSystemWrapper::SerializeOptions(
+    const ConfigOptions& config_options,
+    std::unordered_map<std::string, std::string>* options) const {
+  if (!config_options.IsShallow() && target_ != nullptr &&
+      !target_->IsInstanceOf(FileSystem::kDefaultName())) {
+    options->insert({kTargetPropName(), target_->ToString(config_options)});
   }
+  return FileSystem::SerializeOptions(config_options, options);
 }
 
 DirFsyncOptions::DirFsyncOptions() { reason = kDefault; }

--- a/include/rocksdb/configurable.h
+++ b/include/rocksdb/configurable.h
@@ -343,8 +343,9 @@ class Configurable {
                                std::string* bad_name) const;
   // Internal method to serialize options (ToString)
   // Classes may override this value to change its behavior.
-  virtual std::string SerializeOptions(const ConfigOptions& config_options,
-                                       const std::string& header) const;
+  virtual Status SerializeOptions(
+      const ConfigOptions& config_options,
+      std::unordered_map<std::string, std::string>* options) const;
 
   //  Given a name (e.g. rocksdb.my.type.opt), returns the short name (opt)
   virtual std::string GetOptionName(const std::string& long_name) const;

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -93,13 +93,15 @@ struct ConfigOptions {
   // The object registry to use for this options
   std::shared_ptr<ObjectRegistry> registry;
 
+  // If set, only changes from this reference version will be serialized.
+  Configurable* compare_to = nullptr;
+
   bool IsShallow() const { return depth == Depth::kDepthShallow; }
   bool IsDetailed() const { return depth == Depth::kDepthDetailed; }
 
   bool IsCheckDisabled() const {
     return sanity_level == SanityLevel::kSanityLevelNone;
   }
-
   bool IsCheckEnabled(SanityLevel level) const {
     return (level > SanityLevel::kSanityLevelNone && level <= sanity_level);
   }

--- a/include/rocksdb/convenience.h
+++ b/include/rocksdb/convenience.h
@@ -103,6 +103,13 @@ struct ConfigOptions {
   bool IsCheckEnabled(SanityLevel level) const {
     return (level > SanityLevel::kSanityLevelNone && level <= sanity_level);
   }
+  // Converts the map of options to a single string representation
+  std::string ToString(
+      const std::string& prefix,
+      const std::unordered_map<std::string, std::string>& options) const;
+  // Converts the vector options to a single string representation
+  std::string ToString(char separator,
+                       const std::vector<std::string>& elems) const;
 };
 
 

--- a/include/rocksdb/customizable.h
+++ b/include/rocksdb/customizable.h
@@ -57,6 +57,8 @@ class Customizable : public Configurable {
  public:
   ~Customizable() override {}
 
+  constexpr static const char* kTargetPropName() { return "target"; }
+
   // Returns the name of this class of Customizable
   virtual const char* Name() const = 0;
 
@@ -222,8 +224,9 @@ class Customizable : public Configurable {
   virtual const char* NickName() const { return ""; }
   //  Given a name (e.g. rocksdb.my.type.opt), returns the short name (opt)
   std::string GetOptionName(const std::string& long_name) const override;
-  std::string SerializeOptions(const ConfigOptions& options,
-                               const std::string& prefix) const override;
+  Status SerializeOptions(
+      const ConfigOptions& config_options,
+      std::unordered_map<std::string, std::string>* options) const override;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/env.h
+++ b/include/rocksdb/env.h
@@ -1643,8 +1643,9 @@ class EnvWrapper : public Env {
     target_.env->SanitizeEnvOptions(env_opts);
   }
   Status PrepareOptions(const ConfigOptions& options) override;
-  std::string SerializeOptions(const ConfigOptions& config_options,
-                               const std::string& header) const override;
+  Status SerializeOptions(
+      const ConfigOptions& config_options,
+      std::unordered_map<std::string, std::string>* options) const override;
 
  private:
   Target target_;

--- a/include/rocksdb/file_system.h
+++ b/include/rocksdb/file_system.h
@@ -1514,8 +1514,9 @@ class FileSystemWrapper : public FileSystem {
 
   const Customizable* Inner() const override { return target_.get(); }
   Status PrepareOptions(const ConfigOptions& options) override;
-  std::string SerializeOptions(const ConfigOptions& config_options,
-                               const std::string& header) const override;
+  Status SerializeOptions(
+      const ConfigOptions& config_options,
+      std::unordered_map<std::string, std::string>* options) const override;
 
   virtual IOStatus Poll(std::vector<void*>& io_handles,
                         size_t min_completions) override {

--- a/include/rocksdb/system_clock.h
+++ b/include/rocksdb/system_clock.h
@@ -103,8 +103,9 @@ class SystemClockWrapper : public SystemClock {
   }
 
   Status PrepareOptions(const ConfigOptions& options) override;
-  std::string SerializeOptions(const ConfigOptions& config_options,
-                               const std::string& header) const override;
+  Status SerializeOptions(
+      const ConfigOptions& config_options,
+      std::unordered_map<std::string, std::string>* options) const override;
   const Customizable* Inner() const override { return target_.get(); }
 
  protected:

--- a/memory/memory_allocator.cc
+++ b/memory/memory_allocator.cc
@@ -15,8 +15,9 @@
 namespace ROCKSDB_NAMESPACE {
 namespace {
 static std::unordered_map<std::string, OptionTypeInfo> ma_wrapper_type_info = {
-    {"target", OptionTypeInfo::AsCustomSharedPtr<MemoryAllocator>(
-                   0, OptionVerificationType::kByName, OptionTypeFlags::kNone)},
+    {Customizable::kTargetPropName(),
+     OptionTypeInfo::AsCustomSharedPtr<MemoryAllocator>(
+         0, OptionVerificationType::kByName, OptionTypeFlags::kNone)},
 };
 
 static int RegisterBuiltinAllocators(ObjectLibrary& library,

--- a/options/cf_options.cc
+++ b/options/cf_options.cc
@@ -1157,7 +1157,8 @@ Status GetStringFromMutableCFOptions(const ConfigOptions& config_options,
                                      std::string* opt_string) {
   assert(opt_string);
   opt_string->clear();
-  return OptionTypeInfo::SerializeType(
-      config_options, cf_mutable_options_type_info, &mutable_opts, opt_string);
+  return OptionTypeInfo::TypeToString(config_options, "",
+                                      cf_mutable_options_type_info,
+                                      &mutable_opts, opt_string);
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/configurable_helper.h
+++ b/options/configurable_helper.h
@@ -137,6 +137,11 @@ class ConfigurableHelper {
       const ConfigOptions& config_options, const Configurable& configurable,
       std::unordered_map<std::string, std::string>* options);
 
+  static Status SerializeOption(const ConfigOptions& config_options,
+                                const std::string& opt_name,
+                                const OptionTypeInfo& opt_info,
+                                const void* opt_addr, std::string* value);
+
   // Internal method to list the option names for this object.
   // Classes may override this value to change its behavior.
   // @see ListOptions for more details
@@ -157,6 +162,9 @@ class ConfigurableHelper {
                             const Configurable& this_one,
                             const Configurable& that_one,
                             std::string* mismatch);
+
+  static bool MayBeEquivalent(const Configurable& this_one,
+                              const Configurable& that_one);
 
  private:
   // Looks for the option specified by name in the RegisteredOptions.

--- a/options/configurable_helper.h
+++ b/options/configurable_helper.h
@@ -133,10 +133,9 @@ class ConfigurableHelper {
   // @return OK If the options for this object wer successfully serialized.
   // @return InvalidArgument If one or more of the options could not be
   // serialized.
-  static Status SerializeOptions(const ConfigOptions& config_options,
-                                 const Configurable& configurable,
-                                 const std::string& prefix,
-                                 std::string* result);
+  static Status SerializeOptions(
+      const ConfigOptions& config_options, const Configurable& configurable,
+      std::unordered_map<std::string, std::string>* options);
 
   // Internal method to list the option names for this object.
   // Classes may override this value to change its behavior.

--- a/options/customizable.cc
+++ b/options/customizable.cc
@@ -46,27 +46,18 @@ Status Customizable::GetOption(const ConfigOptions& config_options,
   }
 }
 
-std::string Customizable::SerializeOptions(const ConfigOptions& config_options,
-                                           const std::string& prefix) const {
-  std::string result;
-  std::string parent;
-  std::string id = GetId();
-  if (!config_options.IsShallow() && !id.empty()) {
-    parent = Configurable::SerializeOptions(config_options, "");
-  }
-  if (parent.empty()) {
-    result = id;
-  } else {
-    result.append(prefix);
-    result.append(OptionTypeInfo::kIdPropName());
-    result.append("=");
-    result.append(id);
-    result.append(config_options.delimiter);
-    result.append(parent);
-  }
-  return result;
-}
+Status Customizable::SerializeOptions(
+    const ConfigOptions& config_options,
+    std::unordered_map<std::string, std::string>* options) const {
+  Status s;
+  auto id = GetId();
+  options->insert({OptionTypeInfo::kIdPropName(), id});
 
+  if (!config_options.IsShallow() && !id.empty()) {
+    s = Configurable::SerializeOptions(config_options, options);
+  }
+  return s;
+}
 
 bool Customizable::AreEquivalent(const ConfigOptions& config_options,
                                  const Configurable* other,

--- a/options/customizable_test.cc
+++ b/options/customizable_test.cc
@@ -783,10 +783,10 @@ TEST_F(CustomizableTest, TestStringDepth) {
   std::string opt_str;
   shallow.depth = ConfigOptions::Depth::kDepthShallow;
   ASSERT_OK(c->GetOptionString(shallow, &opt_str));
-  ASSERT_EQ(opt_str, "inner=a;");
+  ASSERT_EQ(opt_str, "inner=a");
   shallow.depth = ConfigOptions::Depth::kDepthDetailed;
   ASSERT_OK(c->GetOptionString(shallow, &opt_str));
-  ASSERT_NE(opt_str, "inner=a;");
+  ASSERT_NE(opt_str, "inner=a");
 }
 
 // Tests that we only get a new customizable when it changes

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -544,22 +544,14 @@ static std::unordered_map<std::string, OptionTypeInfo>
                     addr);
             ConfigOptions embedded = opts;
             embedded.delimiter = ";";
-            int printed = 0;
+            std::vector<std::string> vec;
             for (const auto& listener : *listeners) {
               auto id = listener->GetId();
               if (!id.empty()) {
-                std::string elem_str = listener->ToString(embedded, "");
-                if (printed++ == 0) {
-                  value->append("{");
-                } else {
-                  value->append(":");
-                }
-                value->append(elem_str);
+                vec.push_back(listener->ToString(embedded, ""));
               }
             }
-            if (printed > 0) {
-              value->append("}");
-            }
+            *value = opts.ToString(':', vec);
             return Status::OK();
           },
           nullptr}},
@@ -1118,7 +1110,8 @@ bool MutableDBOptionsAreEqual(const MutableDBOptions& this_options,
 Status GetStringFromMutableDBOptions(const ConfigOptions& config_options,
                                      const MutableDBOptions& mutable_opts,
                                      std::string* opt_string) {
-  return OptionTypeInfo::SerializeType(
-      config_options, db_mutable_options_type_info, &mutable_opts, opt_string);
+  return OptionTypeInfo::TypeToString(config_options, "",
+                                      db_mutable_options_type_info,
+                                      &mutable_opts, opt_string);
 }
 }  // namespace ROCKSDB_NAMESPACE

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -1130,29 +1130,13 @@ Status OptionTypeInfo::SerializeType(
     const std::unordered_map<std::string, OptionTypeInfo>& type_map,
     const void* opt_addr,
     std::unordered_map<std::string, std::string>* options) {
-  Status status;
   for (const auto& iter : type_map) {
     std::string single;
     const auto& opt_name = iter.first;
     const auto& opt_info = iter.second;
     if (opt_info.ShouldSerialize()) {
-      if (!config_options.mutable_options_only) {
-        status =
-            opt_info.Serialize(config_options, opt_name, opt_addr, &single);
-      } else if (opt_info.IsMutable()) {
-        ConfigOptions copy = config_options;
-        copy.mutable_options_only = false;
-        status = opt_info.Serialize(copy, opt_name, opt_addr, &single);
-      } else if (opt_info.IsConfigurable()) {
-        // If it is a Configurable and we are either printing all of the
-        // details or not printing only the name, this option should be
-        // included in the list
-        if (config_options.IsDetailed() ||
-            !opt_info.IsEnabled(OptionTypeFlags::kStringNameOnly)) {
-          status =
-              opt_info.Serialize(config_options, opt_name, opt_addr, &single);
-        }
-      }
+      Status status = ConfigurableHelper::SerializeOption(
+          config_options, opt_name, opt_info, opt_addr, &single);
       if (!status.ok()) {
         return status;
       } else if (!single.empty()) {
@@ -1160,7 +1144,7 @@ Status OptionTypeInfo::SerializeType(
       }
     }
   }
-  return status;
+  return Status::OK();
 }
 
 Status OptionTypeInfo::SerializeStruct(

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -4818,7 +4818,7 @@ TEST_F(OptionTypeInfoTest, TestStaticType) {
   std::string str, mismatch;
 
   ASSERT_OK(
-      OptionTypeInfo::SerializeType(config_options, type_map, &opts, &str));
+      OptionTypeInfo::TypeToString(config_options, "", type_map, &opts, &str));
   ASSERT_FALSE(OptionTypeInfo::TypesAreEqual(config_options, type_map, &opts,
                                              &copy, &mismatch));
   ASSERT_OK(OptionTypeInfo::ParseType(config_options, str, type_map, &copy));

--- a/options/options_test.cc
+++ b/options/options_test.cc
@@ -2234,6 +2234,31 @@ TEST_F(OptionsTest, OptionsListenerTest) {
   ASSERT_OK(RocksDBOptionsParser::VerifyDBOptions(config_opts, orig, copy));
 }
 
+TEST_F(OptionsTest, DBOptionsSerializeChangedOptions) {
+  Options base_options, new_options;
+  Random rnd(301);
+
+  ConfigOptions config;
+  DBOptions base;
+  DBOptions copy;
+  std::string opts_str;
+  ASSERT_OK(GetStringFromDBOptions(config, base, &opts_str));
+  auto dbcfg = DBOptionsAsConfigurable(base);
+  config.compare_to = dbcfg.get();
+  ASSERT_OK(GetStringFromDBOptions(config, copy, &opts_str));
+  copy.paranoid_checks = false;
+  copy.max_background_compactions = 10;
+  ASSERT_OK(GetStringFromDBOptions(config, copy, &opts_str));
+
+  copy.file_checksum_gen_factory = GetFileChecksumGenCrc32cFactory();
+  ASSERT_OK(GetStringFromDBOptions(config, copy, &opts_str));
+
+  base.file_checksum_gen_factory = copy.file_checksum_gen_factory;
+  dbcfg = DBOptionsAsConfigurable(base);
+  config.compare_to = dbcfg.get();
+  ASSERT_OK(GetStringFromDBOptions(config, copy, &opts_str));
+}
+
 const static std::string kCustomEnvName = "Custom";
 const static std::string kCustomEnvProp = "env=" + kCustomEnvName;
 


### PR DESCRIPTION
This PR does a few things:
1) Changes the Configurable::SerializeOptions method to return a map of options.  This map is equivalent to the input map for the ConfigureOptions method.  By returning a map, it will be possible in the future to add different output representations (such as DUMP, JSON, Properties) formats to the string representations of the configurable objects.

2) Add the ability to only serialize options that have changed.  If the "ConfigOptions::compare_to" value is set, only option values that do not match those in the "compare_to" will be part of the serialization.  There are a couple places where one could envision using this parameter.  One use case is to only write to the log file options that are not the default (e.g. only print ColumnFamilyOptions that are not the default value) or that do not match some default (e.g. only print Column Family Options that do not match those for the default column family).  This "printing of only changed options" could be useful in printing less information in the LOG and OPTIONS file, thereby speeding them up and making the contents more concise.