### PR TITLE
Redo of Index/Filter/Data blocks sizes in Block (LRU) Block Cache per CF after rebase on RocksDB 8.1 (#516)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 ### New Features
 * Snapshot optimization - The most important information inside a snapshot is its Sequence number, which allows the compaction to know if the key-value should be deleted or not. The sequence number is being changed when modification happens in the db. This feature allows the db to take a snapshot without acquiring db mutex when the last snapshot has the same sequence number as a new one. In transactional db with mostly read operations, it should improve performance when used with multithreaded environment and as well other scenarios of taking large amount of snapshots with mostly read operations.
 * Add a TablePinningPolicy to the BlockBasedTableOptions.  This class controls when blocks should be pinned in memory for a block based table.  The default behavior uses the MetadataCacheOptions to control pinning and behaves identical to the previous releases. 
+* Redo of Index/Filter/Data blocks sizes in Block (LRU) Block Cache per CF after rebase on RocksDB 8.1 . This was part of v2.3.0 and was broken due to changes made in RocksDB. This feature provides per CF information on the size of its Index / Filter / Data blocks in the block cache (only for LRUCache at the moment). The information is printed to the log and the kBlockCacheCfStats and kFastBlockCacheCfStats properties were added to support obtaining the information programmatically.
 
 ### Enhancements
 * db_bench: add estimate-table-readers-mem benchmark which prints these stats.

--- a/cache/cache_entry_roles.cc
+++ b/cache/cache_entry_roles.cc
@@ -101,4 +101,19 @@ std::string BlockCacheEntryStatsMapKeys::UsedPercent(CacheEntryRole role) {
   return GetPrefixedCacheEntryRoleName(kPrefix, role);
 }
 
+const std::string& BlockCacheCfStatsMapKeys::CfName() {
+  static const std::string kCfName = "cf_name";
+  return kCfName;
+}
+
+const std::string& BlockCacheCfStatsMapKeys::CacheId() {
+  static const std::string kCacheId = "id";
+  return kCacheId;
+}
+
+std::string BlockCacheCfStatsMapKeys::UsedBytes(CacheEntryRole role) {
+  const static std::string kPrefix = "bytes.";
+  return GetPrefixedCacheEntryRoleName(kPrefix, role);
+}
+
 }  // namespace ROCKSDB_NAMESPACE

--- a/cache/cache_entry_stats.h
+++ b/cache/cache_entry_stats.h
@@ -83,7 +83,8 @@ class CacheEntryStatsCollector {
       last_start_time_micros_ = start_time_micros;
       working_stats_.BeginCollection(cache_, clock_, start_time_micros);
 
-      cache_->ApplyToAllEntries(working_stats_.GetEntryCallback(), {});
+      cache_->ApplyToAllEntriesWithOwnerId(working_stats_.GetEntryCallback(),
+                                           {});
       TEST_SYNC_POINT_CALLBACK(
           "CacheEntryStatsCollector::GetStats:AfterApplyToAllEntries", nullptr);
 

--- a/cache/clock_cache.cc
+++ b/cache/clock_cache.cc
@@ -1056,10 +1056,11 @@ void ClockCacheShard<Table>::EraseUnRefEntries() {
 }
 
 template <class Table>
-void ClockCacheShard<Table>::ApplyToSomeEntries(
+void ClockCacheShard<Table>::ApplyToSomeEntriesWithOwnerId(
     const std::function<void(const Slice& key, Cache::ObjectPtr value,
                              size_t charge,
-                             const Cache::CacheItemHelper* helper)>& callback,
+                             const Cache::CacheItemHelper* helper,
+                             Cache::ItemOwnerId item_owner_id)>& callback,
     size_t average_entries_per_lock, size_t* state) {
   // The state is essentially going to be the starting hash, which works
   // nicely even if we resize between calls because we use upper-most
@@ -1086,7 +1087,7 @@ void ClockCacheShard<Table>::ApplyToSomeEntries(
       [callback](const HandleImpl& h) {
         UniqueId64x2 unhashed;
         callback(ReverseHash(h.hashed_key, &unhashed), h.value,
-                 h.GetTotalCharge(), h.helper);
+                 h.GetTotalCharge(), h.helper, Cache::kUnknownItemOwnerId);
       },
       index_begin, index_end, false);
 }
@@ -1134,6 +1135,16 @@ Status ClockCacheShard<Table>::Insert(const Slice& key,
                                       const Cache::CacheItemHelper* helper,
                                       size_t charge, HandleImpl** handle,
                                       Cache::Priority priority) {
+  return InsertWithOwnerId(key, hashed_key, value, helper, charge,
+                           Cache::kUnknownItemOwnerId, handle, priority);
+}
+
+template <class Table>
+Status ClockCacheShard<Table>::InsertWithOwnerId(
+    const Slice& key, const UniqueId64x2& hashed_key, Cache::ObjectPtr value,
+    const Cache::CacheItemHelper* helper, size_t charge,
+    Cache::ItemOwnerId /* item_owner_id */, HandleImpl** handle,
+    Cache::Priority priority) {
   if (UNLIKELY(key.size() != kCacheKeySize)) {
     return Status::NotSupported("ClockCache only supports key size " +
                                 std::to_string(kCacheKeySize) + "B");

--- a/cache/clock_cache.h
+++ b/cache/clock_cache.h
@@ -614,6 +614,12 @@ class ALIGN_AS(CACHE_LINE_SIZE) ClockCacheShard final : public CacheShardBase {
                 Cache::ObjectPtr value, const Cache::CacheItemHelper* helper,
                 size_t charge, HandleImpl** handle, Cache::Priority priority);
 
+  Status InsertWithOwnerId(const Slice& key, const UniqueId64x2& hashed_key,
+                           Cache::ObjectPtr value,
+                           const Cache::CacheItemHelper* helper, size_t charge,
+                           Cache::ItemOwnerId /* item_owner_id */,
+                           HandleImpl** handle, Cache::Priority priority);
+
   HandleImpl* CreateStandalone(const Slice& key, const UniqueId64x2& hashed_key,
                                Cache::ObjectPtr obj,
                                const Cache::CacheItemHelper* helper,
@@ -643,10 +649,11 @@ class ALIGN_AS(CACHE_LINE_SIZE) ClockCacheShard final : public CacheShardBase {
 
   size_t GetTableAddressCount() const;
 
-  void ApplyToSomeEntries(
-      const std::function<void(const Slice& key, Cache::ObjectPtr obj,
+  void ApplyToSomeEntriesWithOwnerId(
+      const std::function<void(const Slice& key, Cache::ObjectPtr value,
                                size_t charge,
-                               const Cache::CacheItemHelper* helper)>& callback,
+                               const Cache::CacheItemHelper* helper,
+                               Cache::ItemOwnerId item_owner_id)>& callback,
       size_t average_entries_per_lock, size_t* state);
 
   void EraseUnRefEntries();

--- a/cache/typed_cache.h
+++ b/cache/typed_cache.h
@@ -301,13 +301,15 @@ class FullTypedCacheInterface
   inline Status InsertFull(
       const Slice& key, TValuePtr value, size_t charge,
       TypedHandle** handle = nullptr, Priority priority = Priority::LOW,
-      CacheTier lowest_used_cache_tier = CacheTier::kNonVolatileBlockTier) {
+      CacheTier lowest_used_cache_tier = CacheTier::kNonVolatileBlockTier,
+      Cache::ItemOwnerId item_owner_id = Cache::kUnknownItemOwnerId) {
     auto untyped_handle = reinterpret_cast<Handle**>(handle);
     auto helper = lowest_used_cache_tier == CacheTier::kNonVolatileBlockTier
                       ? GetFullHelper()
                       : GetBasicHelper();
-    return this->cache_->Insert(key, UpCastValue(value), helper, charge,
-                                untyped_handle, priority);
+    return this->cache_->InsertWithOwnerId(key, UpCastValue(value), helper,
+                                           charge, item_owner_id,
+                                           untyped_handle, priority);
   }
 
   // Like SecondaryCache::InsertSaved, with SecondaryCache compatibility

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -649,6 +649,11 @@ ColumnFamilyData::ColumnFamilyData(
               CacheReservationManagerImpl<CacheEntryRole::kFileMetadata>>(
               bbto->block_cache)));
     }
+
+    if (bbto->block_cache && table_cache_) {
+      cache_owner_id_ = bbto->block_cache->GetNextItemOwnerId();
+      table_cache_->SetBlockCacheOwnerId(cache_owner_id_);
+    }
   }
 }
 
@@ -661,6 +666,12 @@ ColumnFamilyData::~ColumnFamilyData() {
   auto next = next_;
   prev->next_ = next;
   next->prev_ = prev;
+
+  const BlockBasedTableOptions* bbto =
+      ioptions_.table_factory->GetOptions<BlockBasedTableOptions>();
+  if (bbto && bbto->block_cache) {
+    bbto->block_cache->DiscardItemOwnerId(&cache_owner_id_);
+  }
 
   if (!dropped_ && column_family_set_ != nullptr) {
     // If it's dropped, it's already removed from column family set

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -563,6 +563,8 @@ class ColumnFamilyData {
   static constexpr uint64_t kLaggingFlushesThreshold = 10U;
   void SetNumTimedQueuedForFlush(uint64_t num) { num_queued_for_flush_ = num; }
 
+  Cache::ItemOwnerId GetCacheOwnerId() const { return cache_owner_id_; }
+
   // Allocate and return a new epoch number
   uint64_t NewEpochNumber() { return next_epoch_number_.fetch_add(1); }
 
@@ -688,6 +690,8 @@ class ColumnFamilyData {
   uint64_t num_queued_for_flush_ = 0U;
 
   std::atomic<uint64_t> next_epoch_number_;
+
+  Cache::ItemOwnerId cache_owner_id_ = Cache::kUnknownItemOwnerId;
 };
 
 // ColumnFamilySet has interesting thread-safety requirements

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -33,6 +33,14 @@
 #include "util/random.h"
 #include "utilities/fault_injection_fs.h"
 
+#ifdef CALL_WRAPPER
+#undef CALL_WRAPPER
+#endif
+
+#define CALL_WRAPPER(func) \
+  func;                    \
+  ASSERT_FALSE(HasFailure());
+
 namespace ROCKSDB_NAMESPACE {
 
 class DBBlockCacheTest : public DBTestBase {
@@ -144,6 +152,95 @@ class DBBlockCacheTest : public DBTestBase {
           ParseSizeT(values[BlockCacheEntryStatsMapKeys::EntryCount(role)]);
     }
     return cache_entry_role_counts;
+  }
+
+  bool IsLRUCache(Cache* cache) {
+    return (std::string(cache->Name()) == "LRUCache");
+  }
+
+  InternalStats::CacheEntryRoleStats GetCacheEntryRoleStatsBg() {
+    // Verify in cache entry role stats
+    ColumnFamilyHandleImpl* cfh =
+        static_cast<ColumnFamilyHandleImpl*>(dbfull()->DefaultColumnFamily());
+    InternalStats* internal_stats_ptr = cfh->cfd()->internal_stats();
+    InternalStats::CacheEntryRoleStats stats;
+    internal_stats_ptr->TEST_GetCacheEntryRoleStats(&stats,
+                                                    /*foreground=*/false);
+    return stats;
+  }
+
+  void ValidateCacheCfMapProperty(
+      const std::vector<ColumnFamilyHandle*>& cf_handles,
+      const InternalStats::CacheEntryRoleStats& actual_stats) {
+    // Get the general block cache entry stats using the default cf as
+    // we are using only the total used bytes which is the total for all
+    // cf-s in this DB
+    std::map<std::string, std::string> entry_values;
+    ASSERT_TRUE(db_->GetMapProperty(dbfull()->DefaultColumnFamily(),
+                                    DB::Properties::kBlockCacheEntryStats,
+                                    &entry_values));
+    for (auto role : {CacheEntryRole::kDataBlock, CacheEntryRole::kFilterBlock,
+                      CacheEntryRole::kIndexBlock}) {
+      uint64_t total_role_charges_all_cfs_cf_stats = 0U;
+
+      for (const auto cf_handle : cf_handles) {
+        ColumnFamilyHandleImpl* cfh =
+            static_cast<ColumnFamilyHandleImpl*>(cf_handle);
+
+        std::map<std::string, std::string> cf_values;
+        ASSERT_TRUE(db_->GetMapProperty(cfh, DB::Properties::kBlockCacheCfStats,
+                                        &cf_values));
+
+        ASSERT_EQ(cfh->GetName(),
+                  cf_values[BlockCacheCfStatsMapKeys::CfName()]);
+        ASSERT_EQ(actual_stats.cache_id,
+                  cf_values[BlockCacheCfStatsMapKeys::CacheId()]);
+
+        total_role_charges_all_cfs_cf_stats +=
+            std::stoll(cf_values[BlockCacheCfStatsMapKeys::UsedBytes(role)]);
+      }
+
+      auto total_role_charges_global_stats =
+          std::stoll(entry_values[BlockCacheCfStatsMapKeys::UsedBytes(role)]);
+      ASSERT_EQ(total_role_charges_global_stats,
+                total_role_charges_all_cfs_cf_stats)
+          << "Role: " << GetCacheEntryRoleName(role);
+    }
+  }
+
+  void ValidateCacheStats(
+      const std::shared_ptr<Cache>& cache,
+      const std::array<size_t, kNumCacheEntryRoles>& expected_counts) {
+    auto actual_stats = GetCacheEntryRoleStatsBg();
+
+    auto actual_counts = actual_stats.entry_counts;
+    EXPECT_EQ(expected_counts, actual_counts);
+
+    std::vector<ColumnFamilyHandle*> cf_handles(handles_);
+    if (cf_handles.empty()) {
+      cf_handles.push_back(dbfull()->DefaultColumnFamily());
+    };
+
+    if (IsLRUCache(cache.get())) {
+      // For LRU block cache, verify that the per-item owner id counts
+      // are maintained correctly.
+      // This feature is currently only supported in the LRU cache
+      for (auto role :
+           {CacheEntryRole::kDataBlock, CacheEntryRole::kFilterBlock,
+            CacheEntryRole::kIndexBlock}) {
+        auto role_idx = static_cast<uint>(role);
+        size_t total_role_charges_all_cfs = 0U;
+        for (const auto cfh : cf_handles) {
+          auto cfh_impl = static_cast<ColumnFamilyHandleImpl*>(cfh);
+          auto cache_owner_id = cfh_impl->cfd()->GetCacheOwnerId();
+          total_role_charges_all_cfs +=
+              actual_stats.charge_per_item_owner[cache_owner_id][role_idx];
+        }
+        ASSERT_EQ(actual_stats.total_charges[role_idx],
+                  total_role_charges_all_cfs);
+      }
+      ValidateCacheCfMapProperty(cf_handles, actual_stats);
+    }
   }
 };
 
@@ -629,12 +726,21 @@ class MockCache : public LRUCache {
   Status Insert(const Slice& key, Cache::ObjectPtr value,
                 const Cache::CacheItemHelper* helper, size_t charge,
                 Handle** handle, Priority priority) override {
+    return InsertWithOwnerId(key, value, helper, charge,
+                             Cache::kUnknownItemOwnerId, handle, priority);
+  }
+
+  Status InsertWithOwnerId(const Slice& key, Cache::ObjectPtr value,
+                           const Cache::CacheItemHelper* helper, size_t charge,
+                           Cache::ItemOwnerId item_owner_id, Handle** handle,
+                           Priority priority) override {
     if (priority == Priority::LOW) {
       low_pri_insert_count++;
     } else {
       high_pri_insert_count++;
     }
-    return LRUCache::Insert(key, value, helper, charge, handle, priority);
+    return LRUCache::InsertWithOwnerId(key, value, helper, charge,
+                                       item_owner_id, handle, priority);
   }
 };
 
@@ -958,18 +1064,23 @@ TEST_F(DBBlockCacheTest, CacheCompressionDict) {
   }
 }
 
-static void ClearCache(Cache* cache) {
+static void ClearCache(Cache* cache, Cache::ItemOwnerId owner_id_to_clear =
+                                         Cache::kUnknownItemOwnerId) {
   std::deque<std::string> keys;
   Cache::ApplyToAllEntriesOptions opts;
   auto callback = [&](const Slice& key, Cache::ObjectPtr, size_t /*charge*/,
-                      const Cache::CacheItemHelper* helper) {
+                      const Cache::CacheItemHelper* helper,
+                      Cache::ItemOwnerId item_owner_id) {
     if (helper && helper->role == CacheEntryRole::kMisc) {
       // Keep the stats collector
       return;
     }
-    keys.push_back(key.ToString());
+    if ((owner_id_to_clear == Cache::kUnknownItemOwnerId) ||
+        (item_owner_id == owner_id_to_clear)) {
+      keys.push_back(key.ToString());
+    }
   };
-  cache->ApplyToAllEntries(callback, opts);
+  cache->ApplyToAllEntriesWithOwnerId(callback, opts);
   for (auto& k : keys) {
     cache->Erase(k);
   }
@@ -1031,6 +1142,7 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
       // For CacheEntryStatsCollector
       expected[static_cast<size_t>(CacheEntryRole::kMisc)] = 1;
       EXPECT_EQ(expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, expected));
 
       std::array<size_t, kNumCacheEntryRoles> prev_expected = expected;
 
@@ -1042,12 +1154,15 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
       }
       // Within some time window, we will get cached entry stats
       EXPECT_EQ(prev_expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, prev_expected));
       // Not enough to force a miss
       env_->MockSleepForSeconds(45);
       EXPECT_EQ(prev_expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, prev_expected));
       // Enough to force a miss
       env_->MockSleepForSeconds(601);
       EXPECT_EQ(expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, expected));
 
       // Now access index and data block
       ASSERT_EQ("value", Get("foo"));
@@ -1070,6 +1185,7 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
           });
       SyncPoint::GetInstance()->EnableProcessing();
       EXPECT_EQ(expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, expected));
       prev_expected = expected;
       SyncPoint::GetInstance()->DisableProcessing();
       SyncPoint::GetInstance()->ClearAllCallBacks();
@@ -1086,9 +1202,11 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
       // a miss
       env_->MockSleepForSeconds(601);
       EXPECT_EQ(prev_expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, prev_expected));
       // But this is enough
       env_->MockSleepForSeconds(10000);
       EXPECT_EQ(expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, expected));
       prev_expected = expected;
 
       // Also check the GetProperty interface
@@ -1100,6 +1218,27 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
         auto role = static_cast<CacheEntryRole>(i);
         EXPECT_EQ(std::to_string(expected[i]),
                   values[BlockCacheEntryStatsMapKeys::EntryCount(role)]);
+      }
+
+      // Also check the GetProperty interface for CF Stats
+      std::map<std::string, std::string> cf_values;
+      ASSERT_TRUE(
+          db_->GetMapProperty(DB::Properties::kBlockCacheCfStats, &cf_values));
+
+      // We have a single CF ("default") => Validate accordingly for the cf
+      // stats
+      ASSERT_EQ("default", cf_values[BlockCacheCfStatsMapKeys::CfName()]);
+      for (size_t i = 0; i < kNumCacheEntryRoles; ++i) {
+        auto role = static_cast<CacheEntryRole>(i);
+
+        if (IsLRUCache(cache.get())) {
+          ASSERT_EQ(values[BlockCacheEntryStatsMapKeys::UsedBytes(role)],
+                    cf_values[BlockCacheCfStatsMapKeys::UsedBytes(role)]);
+        } else {
+          // CF Stats currently supported only for LRU Cache =>
+          // Otherwise, the cf stats used counts are expected to be 0
+          ASSERT_EQ("0", cf_values[BlockCacheCfStatsMapKeys::UsedBytes(role)]);
+        }
       }
 
       // Add one for kWriteBuffer
@@ -1149,9 +1288,11 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
       expected[static_cast<size_t>(CacheEntryRole::kMisc)]++;
       // Still able to hit on saved stats
       EXPECT_EQ(prev_expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, prev_expected));
       // Enough to force a miss
       env_->MockSleepForSeconds(1000);
       EXPECT_EQ(expected, GetCacheEntryRoleCountsBg());
+      CALL_WRAPPER(ValidateCacheStats(cache, expected));
 
       cache->Release(h);
 
@@ -1214,6 +1355,209 @@ TEST_F(DBBlockCacheTest, CacheEntryRoleStats) {
     }
     EXPECT_GE(iterations_tested, 1);
   }
+}
+
+TEST_F(DBBlockCacheTest, CacheStatsPerCfMultipleCfs) {
+  const size_t capacity = size_t{1} << 25;
+  auto cache{NewLRUCache(capacity)};
+
+  Options options = CurrentOptions();
+  SetTimeElapseOnlySleepOnReopen(&options);
+  options.create_if_missing = true;
+  options.statistics = ROCKSDB_NAMESPACE::CreateDBStatistics();
+  options.max_open_files = 13;
+  options.table_cache_numshardbits = 0;
+  // If this wakes up, it could interfere with test
+  options.stats_dump_period_sec = 0;
+
+  BlockBasedTableOptions table_options;
+  table_options.block_cache = cache;
+  table_options.cache_index_and_filter_blocks = true;
+  table_options.filter_policy.reset(NewBloomFilterPolicy(50));
+  table_options.metadata_cache_options.top_level_index_pinning =
+      PinningTier::kNone;
+  table_options.metadata_cache_options.partition_pinning = PinningTier::kNone;
+  table_options.metadata_cache_options.unpartitioned_pinning =
+      PinningTier::kNone;
+  options.table_factory.reset(NewBlockBasedTableFactory(table_options));
+
+  CreateAndReopenWithCF({"CF1"}, options);
+
+  // Create a new table.
+  ASSERT_OK(Put("foo", "value"));
+  ASSERT_OK(Put("bar", "value"));
+  ASSERT_OK(Flush());
+  ASSERT_EQ(1, NumTableFilesAtLevel(0));
+
+  ASSERT_OK(Put(1, "zfoo", "value"));
+  ASSERT_OK(Put(1, "zbar", "value"));
+  ASSERT_OK(Flush(1));
+  ASSERT_EQ(1, NumTableFilesAtLevel(0, 1));
+
+  // Fresh cache
+  ClearCache(cache.get());
+
+  std::array<size_t, kNumCacheEntryRoles> expected{};
+  // For CacheEntryStatsCollector
+  expected[static_cast<size_t>(CacheEntryRole::kMisc)] = 1;
+  CALL_WRAPPER(ValidateCacheStats(cache, expected));
+
+  // First access only filters
+  ASSERT_EQ("NOT_FOUND", Get("different from any key added"));
+  ASSERT_EQ("NOT_FOUND", Get(1, "different from any key added"));
+  expected[static_cast<size_t>(CacheEntryRole::kFilterBlock)] += 2;
+  // Enough to force a miss
+  env_->MockSleepForSeconds(601);
+  CALL_WRAPPER(ValidateCacheStats(cache, expected));
+
+  // Now access index and data block
+  ASSERT_EQ("value", Get("foo"));
+  expected[static_cast<size_t>(CacheEntryRole::kIndexBlock)]++;
+  expected[static_cast<size_t>(CacheEntryRole::kDataBlock)]++;
+  // Enough to force a miss
+  env_->MockSleepForSeconds(601);
+  CALL_WRAPPER(ValidateCacheStats(cache, expected));
+
+  // The same for other CF
+  ASSERT_EQ("value", Get(1, "zfoo"));
+  expected[static_cast<size_t>(CacheEntryRole::kIndexBlock)]++;
+  expected[static_cast<size_t>(CacheEntryRole::kDataBlock)]++;
+  env_->MockSleepForSeconds(601);
+  CALL_WRAPPER(ValidateCacheStats(cache, expected));
+
+  auto cf1_owner_id = static_cast<ColumnFamilyHandleImpl*>(handles_[1])
+                          ->cfd()
+                          ->GetCacheOwnerId();
+
+  ASSERT_OK(dbfull()->DropColumnFamily(handles_[1]));
+  ASSERT_OK(dbfull()->DestroyColumnFamilyHandle(handles_[1]));
+  handles_.erase(handles_.begin() + 1);
+
+  --expected[static_cast<size_t>(CacheEntryRole::kFilterBlock)];
+  --expected[static_cast<size_t>(CacheEntryRole::kIndexBlock)];
+  --expected[static_cast<size_t>(CacheEntryRole::kDataBlock)];
+
+  // The cache may have items of CF1 in its LRU which will
+  // be counted => remove them explicitly
+  ClearCache(cache.get(), cf1_owner_id);
+
+  env_->MockSleepForSeconds(601);
+  CALL_WRAPPER(ValidateCacheStats(cache, expected));
+
+  ClearCache(cache.get());
+  std::fill(expected.begin(), expected.end(), 0);
+  // For CacheEntryStatsCollector
+  expected[static_cast<size_t>(CacheEntryRole::kMisc)] = 1;
+  env_->MockSleepForSeconds(601);
+  CALL_WRAPPER(ValidateCacheStats(cache, expected));
+
+  // Add some more CF-2
+  CreateColumnFamilies({"CF2", "CF3", "CF4"}, options);
+
+  for (auto cf_id = 1U; cf_id < 4U; ++cf_id) {
+    ASSERT_OK(Put(cf_id, std::string("CF") + std::to_string(cf_id) + "-foo",
+                  "value"));
+    ASSERT_OK(Flush(cf_id));
+    ASSERT_EQ(1, NumTableFilesAtLevel(0, 1));
+  }
+
+  // Fresh cache
+  ClearCache(cache.get());
+
+  ASSERT_EQ("NOT_FOUND", Get(1, "different from any key added"));
+  expected[static_cast<size_t>(CacheEntryRole::kFilterBlock)] += 1;
+
+  ASSERT_EQ("value", Get(2, "CF2-foo"));
+  expected[static_cast<size_t>(CacheEntryRole::kFilterBlock)]++;
+  expected[static_cast<size_t>(CacheEntryRole::kIndexBlock)]++;
+  expected[static_cast<size_t>(CacheEntryRole::kDataBlock)]++;
+
+  env_->MockSleepForSeconds(601);
+  CALL_WRAPPER(ValidateCacheStats(cache, expected));
+}
+
+TEST_F(DBBlockCacheTest, ItemIdAllocation) {
+  const size_t capacity = size_t{1} << 25;
+  auto cache{NewLRUCache(capacity)};
+
+  size_t max_num_ids = Cache::kMaxItemOnwerId - Cache::kMinItemOnwerId + 1;
+  auto expected_num_free_ids = max_num_ids;
+
+  // Allocate 10 id-s
+  auto expected_next_id = Cache::kMinItemOnwerId;
+  for (auto i = 0U; i < 10U; ++i) {
+    ASSERT_EQ(cache->GetNextItemOwnerId(), expected_next_id);
+    ++expected_next_id;
+    --expected_num_free_ids;
+  }
+  --expected_next_id;
+
+  // Release all 10 allocated id-s in reverse order
+  Cache::ItemOwnerId to_discard_id = expected_next_id;
+  for (auto i = 0U; i < 10U; ++i) {
+    auto temp = to_discard_id;
+    cache->DiscardItemOwnerId(&temp);
+    ASSERT_EQ(temp, Cache::kUnknownItemOwnerId);
+
+    ASSERT_GT(to_discard_id, 0U);
+    --to_discard_id;
+    ++expected_num_free_ids;
+  }
+
+  // Allocate 10 id-s and expect to get the id-s from the free list
+  // in the reverse order
+  ASSERT_EQ(expected_next_id, Cache::kMinItemOnwerId + 9U);
+  for (auto i = 0U; i < 10U; ++i) {
+    ASSERT_EQ(cache->GetNextItemOwnerId(), expected_next_id);
+    ASSERT_GT(expected_next_id, 0U);
+    --expected_next_id;
+    --expected_num_free_ids;
+  }
+
+  ASSERT_EQ(expected_num_free_ids, max_num_ids - 10U);
+
+  // Free list should now be empty
+  // Exhaust all of the id-s before wrap around
+  expected_next_id = Cache::kMinItemOnwerId + 10U;
+  while (expected_num_free_ids > 0U) {
+    ASSERT_EQ(cache->GetNextItemOwnerId(), expected_next_id);
+    ++expected_next_id;
+    --expected_num_free_ids;
+  }
+
+  // Expecting next allocations to fail
+  for (auto i = 0U; i < 5U; ++i) {
+    ASSERT_EQ(cache->GetNextItemOwnerId(), Cache::kUnknownItemOwnerId);
+  }
+
+  // Free some arbitrary id-s
+  Cache::ItemOwnerId owner_id = 5000U;
+  cache->DiscardItemOwnerId(&owner_id);
+  owner_id = 1000;
+  cache->DiscardItemOwnerId(&owner_id);
+  owner_id = 3000;
+  cache->DiscardItemOwnerId(&owner_id);
+
+  // Expect allocations to return id-s in the same order as freed
+  ASSERT_EQ(cache->GetNextItemOwnerId(), 5000);
+  ASSERT_EQ(cache->GetNextItemOwnerId(), 1000);
+  ASSERT_EQ(cache->GetNextItemOwnerId(), 3000);
+
+  // All id-s exhausted again
+  ASSERT_EQ(cache->GetNextItemOwnerId(), Cache::kUnknownItemOwnerId);
+
+  // Verify the max size of the free list
+  for (auto i = 0U; i < 2 * Cache::kMaxFreeItemOwnersIdListSize; ++i) {
+    owner_id = Cache::kMinItemOnwerId + i;
+    cache->DiscardItemOwnerId(&owner_id);
+  }
+
+  for (auto i = 0U; i < Cache::kMaxFreeItemOwnersIdListSize; ++i) {
+    ASSERT_EQ(cache->GetNextItemOwnerId(), Cache::kMinItemOnwerId + i);
+  }
+
+  // All id-s exhausted again
+  ASSERT_EQ(cache->GetNextItemOwnerId(), Cache::kUnknownItemOwnerId);
 }
 
 namespace {

--- a/db/internal_stats.cc
+++ b/db/internal_stats.cc
@@ -255,6 +255,9 @@ static const std::string levelstats = "levelstats";
 static const std::string block_cache_entry_stats = "block-cache-entry-stats";
 static const std::string fast_block_cache_entry_stats =
     "fast-block-cache-entry-stats";
+static const std::string block_cache_cf_stats = "block-cache-cf-stats";
+static const std::string fast_block_cache_cf_stats =
+    "fast-block-cache-cf-stats";
 static const std::string num_immutable_mem_table = "num-immutable-mem-table";
 static const std::string num_immutable_mem_table_flushed =
     "num-immutable-mem-table-flushed";
@@ -340,6 +343,10 @@ const std::string DB::Properties::kBlockCacheEntryStats =
     rocksdb_prefix + block_cache_entry_stats;
 const std::string DB::Properties::kFastBlockCacheEntryStats =
     rocksdb_prefix + fast_block_cache_entry_stats;
+const std::string DB::Properties::kBlockCacheCfStats =
+    rocksdb_prefix + block_cache_cf_stats;
+const std::string DB::Properties::kFastBlockCacheCfStats =
+    rocksdb_prefix + fast_block_cache_cf_stats;
 const std::string DB::Properties::kNumImmutableMemTable =
     rocksdb_prefix + num_immutable_mem_table;
 const std::string DB::Properties::kNumImmutableMemTableFlushed =
@@ -476,6 +483,12 @@ const UnorderedMap<std::string, DBPropertyInfo>
         {DB::Properties::kFastBlockCacheEntryStats,
          {true, &InternalStats::HandleFastBlockCacheEntryStats, nullptr,
           &InternalStats::HandleFastBlockCacheEntryStatsMap, nullptr}},
+        {DB::Properties::kBlockCacheCfStats,
+         {true, &InternalStats::HandleBlockCacheCfStats, nullptr,
+          &InternalStats::HandleBlockCacheCfStatsMap, nullptr}},
+        {DB::Properties::kFastBlockCacheCfStats,
+         {true, &InternalStats::HandleFastBlockCacheCfStats, nullptr,
+          &InternalStats::HandleFastBlockCacheCfStatsMap, nullptr}},
         {DB::Properties::kSSTables,
          {false, &InternalStats::HandleSsTables, nullptr, nullptr, nullptr}},
         {DB::Properties::kAggregatedTableProperties,
@@ -676,14 +689,17 @@ void InternalStats::CollectCacheEntryStats(bool foreground) {
 }
 
 std::function<void(const Slice& key, Cache::ObjectPtr value, size_t charge,
-                   const Cache::CacheItemHelper* helper)>
+                   const Cache::CacheItemHelper* helper,
+                   Cache::ItemOwnerId item_owner_id)>
 InternalStats::CacheEntryRoleStats::GetEntryCallback() {
   return [&](const Slice& /*key*/, Cache::ObjectPtr /*value*/, size_t charge,
-             const Cache::CacheItemHelper* helper) -> void {
+             const Cache::CacheItemHelper* helper,
+             Cache::ItemOwnerId item_owner_id) -> void {
     size_t role_idx =
         static_cast<size_t>(helper ? helper->role : CacheEntryRole::kMisc);
     entry_counts[role_idx]++;
     total_charges[role_idx] += charge;
+    charge_per_item_owner[item_owner_id][role_idx] += charge;
   };
 }
 
@@ -744,6 +760,33 @@ std::string InternalStats::CacheEntryRoleStats::ToString(
   return str.str();
 }
 
+std::string InternalStats::CacheEntryRoleStats::CacheOwnerStatsToString(
+    const std::string& cf_name, Cache::ItemOwnerId cache_owner_id) {
+  std::ostringstream str;
+
+  const auto& cf_charges_per_role_pos =
+      charge_per_item_owner.find(cache_owner_id);
+
+  std::vector<CacheEntryRole> roles{CacheEntryRole::kDataBlock,
+                                    CacheEntryRole::kFilterBlock,
+                                    CacheEntryRole::kIndexBlock};
+
+  str << "Block cache [" << cf_name << "] ";
+
+  for (auto role : roles) {
+    auto role_idx = static_cast<unsigned int>(role);
+    uint64_t role_total_charge = 0U;
+    if (cf_charges_per_role_pos != charge_per_item_owner.end()) {
+      role_total_charge = cf_charges_per_role_pos->second[role_idx];
+    }
+
+    str << " " << kCacheEntryRoleToCamelString[role_idx] << "("
+        << BytesToHumanString(role_total_charge) << ")";
+  }
+  str << '\n';
+  return str.str();
+}
+
 void InternalStats::CacheEntryRoleStats::ToMap(
     std::map<std::string, std::string>* values, SystemClock* clock) const {
   values->clear();
@@ -763,6 +806,25 @@ void InternalStats::CacheEntryRoleStats::ToMap(
         std::to_string(total_charges[i]);
     v[BlockCacheEntryStatsMapKeys::UsedPercent(role)] =
         std::to_string(100.0 * total_charges[i] / cache_capacity);
+  }
+}
+
+void InternalStats::CacheEntryRoleStats::CacheOwnerStatsToMap(
+    const std::string& cf_name, Cache::ItemOwnerId cache_owner_id,
+    std::map<std::string, std::string>* values) const {
+  values->clear();
+  auto& v = *values;
+  v[BlockCacheCfStatsMapKeys::CfName()] = cf_name;
+  v[BlockCacheCfStatsMapKeys::CacheId()] = cache_id;
+  const auto& cache_owner_charges = charge_per_item_owner.find(cache_owner_id);
+  for (size_t i = 0; i < kNumCacheEntryRoles; ++i) {
+    auto role = static_cast<CacheEntryRole>(i);
+    if (cache_owner_charges != charge_per_item_owner.end()) {
+      v[BlockCacheCfStatsMapKeys::UsedBytes(role)] =
+          std::to_string(charge_per_item_owner.at(cache_owner_id)[i]);
+    } else {
+      v[BlockCacheCfStatsMapKeys::UsedBytes(role)] = "0";
+    }
   }
 }
 
@@ -808,6 +870,51 @@ bool InternalStats::HandleFastBlockCacheEntryStats(std::string* value,
 bool InternalStats::HandleFastBlockCacheEntryStatsMap(
     std::map<std::string, std::string>* values, Slice /*suffix*/) {
   return HandleBlockCacheEntryStatsMapInternal(values, true /* fast */);
+}
+
+bool InternalStats::HandleBlockCacheCfStatsInternal(std::string* value,
+                                                    bool fast) {
+  if (!cache_entry_stats_collector_) {
+    return false;
+  }
+  CollectCacheEntryStats(!fast /* foreground */);
+  CacheEntryRoleStats stats;
+  cache_entry_stats_collector_->GetStats(&stats);
+  *value =
+      stats.CacheOwnerStatsToString(cfd_->GetName(), cfd_->GetCacheOwnerId());
+  return true;
+}
+
+bool InternalStats::HandleBlockCacheCfStatsMapInternal(
+    std::map<std::string, std::string>* values, bool fast) {
+  if (!cache_entry_stats_collector_) {
+    return false;
+  }
+  CollectCacheEntryStats(!fast /* foreground */);
+  CacheEntryRoleStats stats;
+  cache_entry_stats_collector_->GetStats(&stats);
+  stats.CacheOwnerStatsToMap(cfd_->GetName(), cfd_->GetCacheOwnerId(), values);
+  return true;
+}
+
+bool InternalStats::HandleBlockCacheCfStats(std::string* value,
+                                            Slice /*suffix*/) {
+  return HandleBlockCacheCfStatsInternal(value, false /* fast */);
+}
+
+bool InternalStats::HandleBlockCacheCfStatsMap(
+    std::map<std::string, std::string>* values, Slice /*suffix*/) {
+  return HandleBlockCacheCfStatsMapInternal(values, false /* fast */);
+}
+
+bool InternalStats::HandleFastBlockCacheCfStats(std::string* value,
+                                                Slice /*suffix*/) {
+  return HandleBlockCacheCfStatsInternal(value, true /* fast */);
+}
+
+bool InternalStats::HandleFastBlockCacheCfStatsMap(
+    std::map<std::string, std::string>* values, Slice /*suffix*/) {
+  return HandleBlockCacheCfStatsMapInternal(values, true /* fast */);
 }
 
 bool InternalStats::HandleLiveSstFilesSizeAtTemperature(std::string* value,
@@ -2061,6 +2168,8 @@ void InternalStats::DumpCFStatsNoFileHistogram(bool is_periodic,
     // Skip if stats are extremely old (> 1 day, incl not yet populated)
     if (now_micros - stats.last_end_time_micros_ < kDayInMicros) {
       value->append(stats.ToString(clock_));
+      value->append(stats.CacheOwnerStatsToString(cfd_->GetName(),
+                                                  cfd_->GetCacheOwnerId()));
     }
   }
 }

--- a/db/internal_stats.h
+++ b/db/internal_stats.h
@@ -479,6 +479,10 @@ class InternalStats {
     uint64_t last_start_time_micros_ = 0;
     uint64_t last_end_time_micros_ = 0;
 
+    std::unordered_map<Cache::ItemOwnerId,
+                       std::array<size_t, kNumCacheEntryRoles>>
+        charge_per_item_owner;
+
     void Clear() {
       // Wipe everything except collection_count
       uint32_t saved_collection_count = collection_count;
@@ -488,7 +492,8 @@ class InternalStats {
 
     void BeginCollection(Cache*, SystemClock*, uint64_t start_time_micros);
     std::function<void(const Slice& key, Cache::ObjectPtr value, size_t charge,
-                       const Cache::CacheItemHelper* helper)>
+                       const Cache::CacheItemHelper* helper,
+                       Cache::ItemOwnerId item_owner_id)>
     GetEntryCallback();
     void EndCollection(Cache*, SystemClock*, uint64_t end_time_micros);
     void SkippedCollection();
@@ -496,6 +501,12 @@ class InternalStats {
     std::string ToString(SystemClock* clock) const;
     void ToMap(std::map<std::string, std::string>* values,
                SystemClock* clock) const;
+
+    std::string CacheOwnerStatsToString(const std::string& cf_name,
+                                        Cache::ItemOwnerId cache_owner_id);
+    void CacheOwnerStatsToMap(const std::string& cf_name,
+                              Cache::ItemOwnerId cache_owner_id,
+                              std::map<std::string, std::string>* values) const;
 
    private:
     uint64_t GetLastDurationMicros() const;
@@ -844,6 +855,15 @@ class InternalStats {
                                      Slice suffix);
   bool HandleFastBlockCacheEntryStats(std::string* value, Slice suffix);
   bool HandleFastBlockCacheEntryStatsMap(
+      std::map<std::string, std::string>* values, Slice suffix);
+  bool HandleBlockCacheCfStatsInternal(std::string* value, bool fast);
+  bool HandleBlockCacheCfStatsMapInternal(
+      std::map<std::string, std::string>* values, bool fast);
+  bool HandleBlockCacheCfStats(std::string* value, Slice suffix);
+  bool HandleBlockCacheCfStatsMap(std::map<std::string, std::string>* values,
+                                  Slice suffix);
+  bool HandleFastBlockCacheCfStats(std::string* value, Slice suffix);
+  bool HandleFastBlockCacheCfStatsMap(
       std::map<std::string, std::string>* values, Slice suffix);
   bool HandleLiveSstFilesSizeAtTemperature(std::string* value, Slice suffix);
   bool HandleNumBlobFiles(uint64_t* value, DBImpl* db, Version* version);

--- a/db/table_cache.cc
+++ b/db/table_cache.cc
@@ -137,15 +137,18 @@ Status TableCache::GetTableReader(
     } else {
       expected_unique_id = kNullUniqueId64x2;  // null ID == no verification
     }
+
+    TableReaderOptions table_reader_options(
+        ioptions_, prefix_extractor, file_options, internal_comparator,
+        skip_filters, immortal_tables_, false /* force_direct_prefetch */,
+        level, is_bottom, block_cache_tracer_, max_file_size_for_l0_meta_pin,
+        db_session_id_, file_meta.fd.GetNumber(), expected_unique_id,
+        file_meta.fd.largest_seqno);
+    table_reader_options.cache_owner_id = cache_owner_id_;
+
     s = ioptions_.table_factory->NewTableReader(
-        ro,
-        TableReaderOptions(ioptions_, prefix_extractor, file_options,
-                           internal_comparator, skip_filters, immortal_tables_,
-                           false /* force_direct_prefetch */, level, is_bottom,
-                           block_cache_tracer_, max_file_size_for_l0_meta_pin,
-                           db_session_id_, file_meta.fd.GetNumber(),
-                           expected_unique_id, file_meta.fd.largest_seqno),
-        std::move(file_reader), file_meta.fd.GetFileSize(), table_reader,
+        ro, table_reader_options, std::move(file_reader),
+        file_meta.fd.GetFileSize(), table_reader,
         prefetch_index_and_filter_in_cache);
     TEST_SYNC_POINT("TableCache::GetTableReader:0");
   }

--- a/db/table_cache.h
+++ b/db/table_cache.h
@@ -227,6 +227,10 @@ class TableCache {
     }
   }
 
+  void SetBlockCacheOwnerId(Cache::ItemOwnerId cache_owner_id) {
+    cache_owner_id_ = cache_owner_id;
+  }
+
  private:
   // Build a table reader
   Status GetTableReader(
@@ -268,6 +272,7 @@ class TableCache {
   Striped<port::Mutex, Slice> loader_mutex_;
   std::shared_ptr<IOTracer> io_tracer_;
   std::string db_session_id_;
+  Cache::ItemOwnerId cache_owner_id_ = Cache::kUnknownItemOwnerId;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/include/rocksdb/cache.h
+++ b/include/rocksdb/cache.h
@@ -88,6 +88,16 @@ struct BlockCacheEntryStatsMapKeys {
   static std::string UsedPercent(CacheEntryRole);
 };
 
+// For use with `GetMapProperty()` for property
+// `DB::Properties::kBlockCacheCfStats` and
+// 'DB::Properties::kFastBlockCacheCfStats' On success, the map will be
+// populated with all keys that can be obtained from these functions.
+struct BlockCacheCfStatsMapKeys {
+  static const std::string& CfName();
+  static const std::string& CacheId();
+  static std::string UsedBytes(CacheEntryRole);
+};
+
 extern const bool kDefaultToAdaptiveMutex;
 
 enum CacheMetadataChargePolicy {

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -986,6 +986,14 @@ class DB {
     //      stale values more frequently to reduce overhead and latency.
     static const std::string kFastBlockCacheEntryStats;
 
+    //  "rocksdb.block-cache-cf-stats" - returns a multi-line string
+    //      with statistics on block cache usage for a specific column-family.
+    static const std::string kBlockCacheCfStats;
+
+    //  "rocksdb.fast-block-cache-cf-stats" - same as above, but returns
+    //      stale values more frequently to reduce overhead and latency.
+    static const std::string kFastBlockCacheCfStats;
+
     //  "rocksdb.num-immutable-mem-table" - returns number of immutable
     //      memtables that have not yet been flushed.
     static const std::string kNumImmutableMemTable;

--- a/table/block_based/block_based_table_factory.cc
+++ b/table/block_based/block_based_table_factory.cc
@@ -585,7 +585,7 @@ Status BlockBasedTableFactory::NewTableReader(
       table_reader_options.block_cache_tracer,
       table_reader_options.max_file_size_for_l0_meta_pin,
       table_reader_options.cur_db_session_id, table_reader_options.cur_file_num,
-      table_reader_options.unique_id);
+      table_reader_options.unique_id, table_reader_options.cache_owner_id);
 }
 
 TableBuilder* BlockBasedTableFactory::NewTableBuilder(

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -570,7 +570,8 @@ Status BlockBasedTable::Open(
     TailPrefetchStats* tail_prefetch_stats,
     BlockCacheTracer* const block_cache_tracer,
     size_t max_file_size_for_l0_meta_pin, const std::string& cur_db_session_id,
-    uint64_t cur_file_num, UniqueId64x2 expected_unique_id) {
+    uint64_t cur_file_num, UniqueId64x2 expected_unique_id,
+    Cache::ItemOwnerId cache_owner_id) {
   table_reader->reset();
 
   Status s;
@@ -629,9 +630,9 @@ Status BlockBasedTable::Open(
   }
 
   BlockCacheLookupContext lookup_context{TableReaderCaller::kPrefetch};
-  Rep* rep = new BlockBasedTable::Rep(ioptions, env_options, table_options,
-                                      internal_comparator, skip_filters,
-                                      file_size, level, immortal_table);
+  Rep* rep = new BlockBasedTable::Rep(
+      ioptions, env_options, table_options, internal_comparator, skip_filters,
+      file_size, level, immortal_table, cache_owner_id);
   rep->file = std::move(file);
   rep->footer = footer;
 
@@ -1327,7 +1328,8 @@ WithBlocklikeCheck<Status, TBlocklike> BlockBasedTable::PutDataBlockToCache(
     BlockCacheTypedHandle<TBlocklike>* cache_handle = nullptr;
     s = block_cache.InsertFull(cache_key, block_holder.get(), charge,
                                &cache_handle, GetCachePriority<TBlocklike>(),
-                               rep_->ioptions.lowest_used_cache_tier);
+                               rep_->ioptions.lowest_used_cache_tier,
+                               rep_->cache_owner_id);
 
     if (s.ok()) {
       assert(cache_handle != nullptr);

--- a/table/table_builder.h
+++ b/table/table_builder.h
@@ -20,6 +20,7 @@
 #include "db/table_properties_collector.h"
 #include "file/writable_file_writer.h"
 #include "options/cf_options.h"
+#include "rocksdb/cache.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table_properties.h"
 #include "table/unique_id_impl.h"
@@ -90,6 +91,8 @@ struct TableReaderOptions {
 
   // Known unique_id or {}, kNullUniqueId64x2 means unknown
   UniqueId64x2 unique_id;
+
+  Cache::ItemOwnerId cache_owner_id = Cache::kUnknownItemOwnerId;
 };
 
 struct TableBuilderOptions {


### PR DESCRIPTION
The original issue is: https://github.com/speedb-io/speedb/issues/338