### PR TITLE
Export GetCompactionReasonString/GetFlushReasonString by moving them into listener.h

### DIFF
--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -161,6 +161,8 @@ enum class CompactionReason : int {
   kNumOfReasons,
 };
 
+const char* GetCompactionReasonString(CompactionReason compaction_reason);
+
 enum class FlushReason : int {
   kOthers = 0x00,
   kGetLiveFiles = 0x01,
@@ -180,6 +182,8 @@ enum class FlushReason : int {
   kWalFull = 0xd,
   kWriteBufferManagerInitiated = 0xe,
 };
+
+const char* GetFlushReasonString(FlushReason flush_reason);
 
 // TODO: In the future, BackgroundErrorReason will only be used to indicate
 // why the BG Error is happening (e.g., flush, compaction). We may introduce


### PR DESCRIPTION
Currently, rocksdb users would use the event listener to catch the compaction/flush event and log them if any. But now the reason is an integer type instead of a human-readable string, so we would like to convert them into a human-readable string.

Refer: https://github.com/facebook/rocksdb/pull/11778