### PR TITLE
Fix unused variable warnings in db_bench_tool.cc

### DIFF
--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -7690,17 +7690,13 @@ class Benchmark {
 
     fprintf(stderr, "num reads to do %" PRIu64 "\n", reads_);
     Duration duration(FLAGS_duration, reads_);
-    uint64_t num_seek_to_first = 0;
-    uint64_t num_next = 0;
     while (!duration.Done(1)) {
       if (!iter->Valid()) {
         iter->SeekToFirst();
-        num_seek_to_first++;
       } else if (!iter->status().ok()) {
         ErrorExit("Iterator error: %s", iter->status().ToString().c_str());
       } else {
         iter->Next();
-        num_next++;
       }
 
       thread->stats.FinishedOps(&single_db, single_db.db, 1, kSeek);


### PR DESCRIPTION
num_seek_to_first and num_next are not used in db_bench_tool. It will throw warnings and then fail to build.


```shell
/Users/hulk/code/cxx/speedb/tools/db_bench_tool.cc:7693:14: error: variable 'num_seek_to_first' set but not used [-Werror,-Wunused-but-set-variable]
    uint64_t num_seek_to_first = 0;
             ^
/Users/hulk/code/cxx/speedb/tools/db_bench_tool.cc:7694:14: error: variable 'num_next' set but not used [-Werror,-Wunused-but-set-variable]
    uint64_t num_next = 0;
```