### PR TITLE
CI: Fix check history, add fetch-depth 0 for base sha

### DIFF
--- a/.github/workflows/check_license_and_history.yml
+++ b/.github/workflows/check_license_and_history.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Check License
         run: |  
           exit_code=0


### PR DESCRIPTION
check history step is unable to check the base sha due to fetch-depth not being set to 0.
``` fatal: bad object bedf640182e490efa34cd493d6a8844e394d906c ```

