### PR TITLE
Export GetFlushReasonString/GetCompactionReasonString in listener.h

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ Based on RocksDB 8.6.7
 
 ### Enhancements
 * Added a kUseBaseAddress flag and GetBaseOffset flag to OptionTypeInfo.  If this flag is set and a function is used for processing options, the function is passed the base address of the struct rather than the specific field (#397)
+* Export GetFlushReasonString/GetCompactionReasonString in listener.h (#785).
 
 ### Bug Fixes
 * Stall deadlock consists small cfs (#637).

--- a/include/rocksdb/listener.h
+++ b/include/rocksdb/listener.h
@@ -175,6 +175,8 @@ enum class CompactionReason : int {
   kNumOfReasons,
 };
 
+const char* GetCompactionReasonString(CompactionReason compaction_reason);
+
 // When adding flush reason, make sure to also update `GetFlushReasonString()`.
 enum class FlushReason : int {
   kOthers = 0x00,
@@ -197,6 +199,8 @@ enum class FlushReason : int {
   kCatchUpAfterErrorRecovery = 0xe,
   kWriteBufferManagerInitiated = 0xf
 };
+
+const char* GetFlushReasonString(FlushReason flush_reason);
 
 // TODO: In the future, BackgroundErrorReason will only be used to indicate
 // why the BG Error is happening (e.g., flush, compaction). We may introduce


### PR DESCRIPTION
The GetFlushReasonString/GetCompactionReasonString are exported in rocksdb(PR [#11778](https://github.com/facebook/rocksdb/pull/11778))
and Apache Kvrocks would like to use them to avoid copying those reason strings: https://github.com/apache/kvrocks/pull/1962