### PR TITLE
Compaction: Restore SetupForCompaction functionality

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 * Stall deadlock consists small cfs (#637).
 * Proactive Flushes: Fix a race in the ShouldInitiateAnotherFlushMemOnly that may cause the method to return an incorrect answer (#758).
+* Compaction: Restore SetupForCompaction functionality. Specifically, hint POSIX_FADV_NORMAL for compaction input files.See https://github.com/speedb-io/speedb/issues/787 for full details.
 
 ### Miscellaneous
 * Remove leftover references to ROCKSDB_LITE (#755).

--- a/table/block_based/block_based_table_reader.cc
+++ b/table/block_based/block_based_table_reader.cc
@@ -1193,7 +1193,9 @@ Status BlockBasedTable::PrefetchIndexAndFilterBlocks(
   return s;
 }
 
-void BlockBasedTable::SetupForCompaction() {}
+void BlockBasedTable::SetupForCompaction() {
+  rep_->file->file()->Hint(FSRandomAccessFile::kNormal);
+}
 
 TablePinningPolicy* BlockBasedTable::GetPinningPolicy() const {
   return rep_->table_options.pinning_policy.get();


### PR DESCRIPTION
In https://github.com/facebook/rocksdb/pull/11658, files are no longer controlled by the access_hint_on_compaction_start flag by removing the content of SetupForCompaction. However, this leads to degradation in compaction read speed when combined with compaction_readahead_size since once a file is opened, in linux, it is hinted with POSIX_FADV_RANDOM.

See https://github.com/speedb-io/speedb/issues/787 for full details.

Add back the default hint to avoid degradation in this scenario.