### PR TITLE
Options: Set compaction_readahead_size default to 0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@ Based on RocksDB 8.6.7
 
 ### Miscellaneous
 * Remove leftover references to ROCKSDB_LITE (#755).
+* Options: Set compaction_readahead_size default to 0. The current default of 2Mb is not optimal for most of our use cases. Having a value of 0 means that the FS will use its default size for prefetching (true only with https://github.com/speedb-io/speedb/pull/788).
 
 ## Hazlenut 2.7.0 (27/10/2023)
 Based on RocksDB 8.1.1

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1005,10 +1005,10 @@ struct DBOptions {
   // running RocksDB on spinning disks, you should set this to at least 2MB.
   // That way RocksDB's compaction is doing sequential instead of random reads.
   //
-  // Default: 2MB
+  // Default: 0
   //
   // Dynamically changeable through SetDBOptions() API.
-  size_t compaction_readahead_size = 2 * 1024 * 1024;
+  size_t compaction_readahead_size = 0;
 
   // This is a maximum buffer size that is used by WinMmapReadableFile in
   // unbuffered disk I/O mode. We need to maintain an aligned buffer for


### PR DESCRIPTION
The current value of 2Mb is not optimal for most of our use cases. 
By setting the value to 0, we ensure that the prefetch size during compaction read will be the default for that instance.

related to https://github.com/speedb-io/speedb/issues/787.