### PR TITLE
fix CI failure after changing compation_readahead_size default to 0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@ Based on RocksDB 8.6.7
 ### Bug Fixes
 * Stall deadlock consists small cfs (#637).
 * Proactive Flushes: Fix a race in the ShouldInitiateAnotherFlushMemOnly that may cause the method to return an incorrect answer (#758).
+* Fix CI failure after changing compation_readahead_size default to 0 (#794).
 
 ### Miscellaneous
 * Remove leftover references to ROCKSDB_LITE (#755).

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -1069,8 +1069,7 @@ TEST_F(DBOptionsTest, CompactionReadaheadSizeChange) {
       ASSERT_OK(s);
     }
 
-    ASSERT_EQ(1024 * 1024 * 2,
-              dbfull()->GetDBOptions().compaction_readahead_size);
+    ASSERT_EQ(0, dbfull()->GetDBOptions().compaction_readahead_size);
     ASSERT_OK(dbfull()->SetDBOptions({{"compaction_readahead_size", "256"}}));
     ASSERT_EQ(256, dbfull()->GetDBOptions().compaction_readahead_size);
     for (int i = 0; i < 1024; i++) {

--- a/file/prefetch_test.cc
+++ b/file/prefetch_test.cc
@@ -171,6 +171,7 @@ TEST_P(PrefetchTest, Basic) {
   SyncPoint::GetInstance()->SetCallBack("FilePrefetchBuffer::Prefetch:Start",
                                         [&](void*) { buff_prefetch_count++; });
   SyncPoint::GetInstance()->EnableProcessing();
+  options.compaction_readahead_size = 2 * 1024 * 1024;
 
   Status s = TryReopen(options);
   if (use_direct_io && (s.IsNotSupported() || s.IsInvalidArgument())) {


### PR DESCRIPTION
fix CI failure after changing compation_readahead_size default to 0

fixes: https://github.com/speedb-io/speedb/issues/793