### PR TITLE
stress test: Fix TestIterateAgainstExpected not supporting 0 iterations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,8 @@ Based on RocksDB 8.6.7
 * Proactive Flushes: Fix a race in the ShouldInitiateAnotherFlushMemOnly that may cause the method to return an incorrect answer (#758).
 * Fix CI failure after changing compation_readahead_size default to 0 (#794).
 * Compaction: Restore SetupForCompaction functionality. Specifically, hint POSIX_FADV_NORMAL for compaction input files.See https://github.com/speedb-io/speedb/issues/787 for full details.
+* stress test: Fix TestIterateAgainstExpected not supporting 0 iterations. TestIterateAgainstExpected was not designed to support value of 0 in FLAGS_num_iterations.
+RocksDB has a value of 10 by default and we've added the option to randomize the values from 0 to 100 in https://github.com/speedb-io/speedb/commit/434692a63318036a3995a53001337f18bf467903
 
 ### Miscellaneous
 * Remove leftover references to ROCKSDB_LITE (#755).

--- a/tools/db_crashtest.py
+++ b/tools/db_crashtest.py
@@ -243,7 +243,7 @@ default_params = {
     "allow_concurrent_memtable_write": lambda: random.randint(0, 1),
     # only done when thread#0 does TestAcquireSnapshot. 
     "compare_full_db_state_snapshot": lambda: random.choice([0, 0, 0, 1]),
-    "num_iterations": lambda: random.randint(0, 100),
+    "num_iterations": lambda: random.randint(1, 100),
     "sync_wal_one_in": 100000,
     "customopspercent": 0,
     # "filter_uri": lambda: random.choice(["speedb.PairedBloomFilter", ""]),


### PR DESCRIPTION
TestIterateAgainstExpected was not designed to support value of 0 in FLAGS_num_iterations. RocksDB has a value of 10 by default and we've added the option to randomize the values from 0 to 100 in https://github.com/speedb-io/speedb/commit/434692a63318036a3995a53001337f18bf467903

Fix by limiting to 1 - 100.

error:
```
./db_stress --acquire_snapshot_one_in=10000 --adaptive_readahead=0 --allow_concurrent_memtable_write=1 --allow_data_in_errors=True --allow_wbm_stalls=1 --async_io=0 --avoid_flush_during_recovery=1 --avoid_unnecessary_blocking_io=1 --backup_max_size=104857600 --backup_one_in=100000 --batch_protection_bytes_per_key=0 --block_protection_bytes_per_key=2 --block_size=16384 --bloom_bits=3.242941150392554 --bottommost_compression_type=disable --bottommost_file_compaction_delay=600 --bytes_per_sync=262144 --cache_index_and_filter_blocks=0 --cache_size=8388608 --cache_type=auto_hyper_clock_cache --charge_compression_dictionary_building_buffer=1 --charge_file_metadata=1 --charge_filter_construction=1 --charge_table_reader=0 --checkpoint_one_in=1000000 --checksum_type=kxxHash64 --clear_column_family_one_in=0 --column_families=1 --compact_files_one_in=1000000 --compact_range_one_in=1000000 --compaction_pri=3 --compaction_ttl=0 --compare_full_db_state_snapshot=1 --compression_checksum=0 --compression_max_dict_buffer_bytes=549755813887 --compression_max_dict_bytes=16384 --compression_parallel_threads=1 --compression_type=snappy --compression_use_zstd_dict_trainer=1 --compression_zstd_max_train_bytes=0 --continuous_verification_interval=0 --crash_test=1 --customopspercent=0 --data_block_index_type=0 --db=/tmp/rocksdb_crashtest_blackboxll6ttbpy --db_write_buffer_size=134217728 --delpercent=24 --delrangepercent=3 --destroy_db_initially=0 --detect_filter_construct_corruption=1 --disable_wal=0 --enable_compaction_filter=0 --enable_pipelined_write=0 --enable_speedb_features=1 --enable_thread_tracking=1 --expected_values_dir=/tmp/rocksdb_crashtest_expected_ybnubg3m --fail_if_options_file_error=0 --fifo_allow_compaction=0 --file_checksum_impl=crc32c --flush_one_in=1000000 --format_version=3 --get_current_wal_file_one_in=0 --get_live_files_one_in=100000 --get_property_one_in=1000000 --get_sorted_wal_files_one_in=0 --index_block_restart_interval=10 --index_type=0 --ingest_external_file_one_in=0 --initial_auto_readahead_size=0 --initiate_wbm_flushes=0 --iterpercent=30 --key_len_percent_dist=4,6,70,20 --level_compaction_dynamic_level_bytes=1 --lock_wal_one_in=1000000 --long_running_snapshots=0 --manual_wal_flush_one_in=1000 --mark_for_compaction_one_file_in=0 --max_auto_readahead_size=524288 --max_background_compactions=1 --max_background_jobs=8 --max_bytes_for_level_base=67108864 --max_key=102400 --max_key_len=4 --max_manifest_file_size=1073741824 --max_write_batch_group_size_bytes=64 --max_write_buffer_number=3 --max_write_buffer_size_to_maintain=0 --memtable_max_range_deletions=0 --memtable_prefix_bloom_size_ratio=0.01 --memtable_protection_bytes_per_key=8 --memtable_whole_key_filtering=0 --memtablerep=skip_list --min_write_buffer_number_to_merge=1 --mmap_read=0 --mock_direct_io=False --nooverwritepercent=5 --num_file_reads_for_auto_readahead=1 --num_iterations=0 --open_files=-1 --open_metadata_write_fault_one_in=0 --open_read_fault_one_in=0 --open_write_fault_one_in=0 --ops_per_thread=100000000 --optimize_filters_for_memory=0 --paranoid_file_checks=1 --partition_filters=0 --partition_pinning=3 --pause_background_one_in=1000000 --periodic_compaction_seconds=1000 --pinning_policy=default --prefix_size=8 --prefixpercent=6 --prepopulate_block_cache=0 --preserve_internal_time_seconds=60 --progress_reports=0 --read_fault_one_in=1000 --readahead_size=0 --readpercent=2 --recycle_log_file_num=1 --reopen=0 --ribbon_starting_level=4 --secondary_cache_fault_one_in=32 --secondary_cache_uri=compressed_secondary_cache://capacity=8388608 --seed=2532455246 --set_options_one_in=0 --snapshot_hold_ops=100000 --sst_file_manager_bytes_per_sec=0 --sst_file_manager_bytes_per_truncate=0 --start_delay_percent=48 --stats_dump_period_sec=0 --subcompactions=2 --sync=0 --sync_fault_injection=0 --sync_wal_one_in=100000 --target_file_size_base=16777216 --target_file_size_multiplier=1 --test_batches_snapshots=0 --top_level_index_pinning=1 --total_ram_size=536870912 --unpartitioned_pinning=0 --use_direct_io_for_flush_and_compaction=1 --use_direct_reads=1 --use_dynamic_delay=1 --use_full_merge_v1=0 --use_get_entity=0 --use_merge=0 --use_multi_get_entity=0 --use_multiget=1 --use_put_entity_one_in=5 --user_timestamp_size=0 --value_size_mult=32 --verify_before_write=False --verify_checksum=1 --verify_checksum_one_in=1000000 --verify_db_one_in=100000 --verify_file_checksums_one_in=1000000 --verify_iterator_with_expected_state_one_in=5 --verify_sst_unique_id_in_manifest=1 --wal_bytes_per_sync=0 --wal_compression=none --write_buffer_size=33554432 --write_dbid_to_manifest=1 --writepercent=35


b"WARNING: prefix_size is non-zero but memtablerep != prefix_hash\ndb_stress: db_stress_tool/no_batched_ops_stress.cc:1798: virtual rocksdb::Status rocksdb::NonBatchedOpsStressTest::TestIterateAgainstExpected(rocksdb::ThreadState*, const rocksdb::ReadOptions&, const std::vector<int>&, const std::vector<long int>&): Assertion `lb < last_key' failed.\nReceived signal 6 (Aborted)\nInvoking GDB for stack trace...\ndb_stress: db_stress_tool/no_batched_ops_stress.cc:1798: virtual rocksdb::Status rocksdb::NonBatchedOpsStressTest::TestIterateAgainstExpected(rocksdb::ThreadState*, const rocksdb::ReadOptions&, const std::vector<int>&, const std::vector<long int>&): Assertion `lb < last_key' failed.\n"
```