### PR TITLE
IsEmpty() checks were missing before some SwitchMemtable() invocation…

### DIFF
--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -2140,7 +2140,10 @@ Status DBImpl::SwitchMemtable(ColumnFamilyData* cfd, WriteContext* context) {
   log::Writer* new_log = nullptr;
   MemTable* new_mem = nullptr;
   IOStatus io_s;
-
+  
+  if(cfd->mem()->IsEmpty()) {
+    return Status::OK();
+  }
   // Recoverable state is persisted in WAL. After memtable switch, WAL might
   // be deleted, so we write the state to memtable to be persisted as well.
   Status s = WriteRecoverableState();


### PR DESCRIPTION
Bug: https://github.com/facebook/rocksdb/issues/12179

There was one instance where the IsEmpty() check was missing:

[rocksdb/db/db_impl/db_impl_write.cc](https://github.com/facebook/rocksdb/blob/21d5a8f54f06e01ca49d4e6bae89bb42ba78dfdd/db/db_impl/db_impl_write.cc#L1706)

Line 1706 in [21d5a8f](https://github.com/facebook/rocksdb/commit/21d5a8f54f06e01ca49d4e6bae89bb42ba78dfdd)

 status = SwitchMemtable(cfd, write_context); 
Having one check inside SwitchMemTable() will ensure there won't be misses in the future.