### PR TITLE
Remove some db stress non existence parameters

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@ Based on RocksDB 8.6.7
 * LOG Enhancement: Have a separate LOG entry per CF Stats. This ensures that no CF stats data is lost in case the size of the combined CF stats text exceeds the LOG's threshold (#534).
 
 ### Bug Fixes
+* Fix a bug in db_stress where non existence parameters have checked with enable_speedb_features.
 * Added IsRefreshIterSupported() to memtable_rep, to publish if the memtable support Refresh() of the iterator.
 Refresh() will return status NotSupported for memtables that do not support Refresh().
 IsAllowRefresh() has been added.

--- a/db_stress_tool/db_stress_test_base.cc
+++ b/db_stress_tool/db_stress_test_base.cc
@@ -147,19 +147,21 @@ bool is_default(const char* flag_name) {
 }
 
 void ValidateEnableSpeedbFlags() {
-  std::vector<std::string> confilct_flags = {
-      "num_high_pri_threads", "num_bottom_pri_threads",
-      "num_bottom_pri_threads", "num_low_pri_threads",
-      "max_background_compactions", "max_background_flushes", "cache_size",
-      "cache_type",
-      // Assume simcache_size default is disabled simcache
-      "simcache_size", "memtablerep", "pinning_policy",
-      "scoped_pinning_capacity", "use_ribbon_filter", "bloom_bits",
-      "allow_wbm_stalls", "db_write_buffer_size", "initiate_wbm_flushes",
-      "bytes_per_sync", "use_dynamic_delay", "memtable_bloom_size_ratio",
-      "whole_key_filtering", "optimize_filters_for_hits",
-      "max_num_parallel_flushes", "start_delay_percent",
-      "max_num_parallel_flushes", "use_blob_cache"};
+  std::vector<std::string> confilct_flags = {"max_background_compactions",
+                                             "max_background_flushes",
+                                             "cache_size",
+                                             "cache_type",
+                                             "memtablerep",
+                                             "pinning_policy",
+                                             "bloom_bits",
+                                             "allow_wbm_stalls",
+                                             "db_write_buffer_size",
+                                             "initiate_wbm_flushes",
+                                             "bytes_per_sync",
+                                             "use_dynamic_delay",
+                                             "start_delay_percent",
+                                             "max_num_parallel_flushes",
+                                             "use_blob_cache"};
 
   if (FLAGS_enable_speedb_features && !FLAGS_crash_test) {
     if (is_default("max_background_jobs") || is_default("total_ram_size")) {


### PR DESCRIPTION
There is a bug that ValidateEnableSpeedbFlags() checks for non existence parameters in db_stress