### PR TITLE
Fix cross-compilation on macOS x86_64 CPUs with target CPU arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,29 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW)
 endif()
 
+if(APPLE)
+  # On macOS Cmake, when cross-compiling, sometimes CMAKE_SYSTEM_PROCESSOR wrongfully stays
+  # the same as CMAKE_HOST_SYSTEM_PROCESSOR regardless the target CPU.
+  # The manual call to  set(CMAKE_SYSTEM_PROCESSOR) has to be set after the project() call.
+  # because project() might reset CMAKE_SYSTEM_PROCESSOR back to the value of CMAKE_HOST_SYSTEM_PROCESSOR.
+  # Check if CMAKE_SYSTEM_PROCESSOR is not equal to CMAKE_OSX_ARCHITECTURES
+  if(NOT CMAKE_OSX_ARCHITECTURES STREQUAL "")
+    if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL CMAKE_OSX_ARCHITECTURES)
+      # Split CMAKE_OSX_ARCHITECTURES into a list
+      string(REPLACE ";" " " ARCH_LIST ${CMAKE_OSX_ARCHITECTURES})
+      separate_arguments(ARCH_LIST UNIX_COMMAND ${ARCH_LIST})
+      # Count the number of architectures
+      list(LENGTH ARCH_LIST ARCH_COUNT)
+      # Ensure that exactly one architecture is specified
+      if(NOT ARCH_COUNT EQUAL 1)
+        message(FATAL_ERROR "CMAKE_OSX_ARCHITECTURES must have exactly one value. Current value: ${CMAKE_OSX_ARCHITECTURES}")
+      endif()
+      set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_OSX_ARCHITECTURES})
+      message(STATUS "CMAKE_SYSTEM_PROCESSOR is manually set to ${CMAKE_SYSTEM_PROCESSOR}")
+    endif()
+  endif()
+endif()
+
 if(NOT CMAKE_BUILD_TYPE)
   if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     set(default_build_type "Debug")

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -44,7 +44,7 @@ RocksDB has a value of 10 by default and we've added the option to randomize the
 * Add more checks for using db_stress with --enable_speedb_features=true
 * Proactive Flushes: Have the initiator return a correct answer when it was requested to initate a flush (#812).
 * stress test: Adding a trace file by default in PR https://github.com/speedb-io/speedb/pull/797 has revealed some incompatibilities between the trace file and several configurations (more details in https://github.com/speedb-io/speedb/issues/813). Keep the trace file and remove the IsDone assertion.
-
+* Allow cross-compilation on macOS systems when using Cmake. See https://github.com/speedb-io/speedb/issues/822 for full details.
 
 ### Miscellaneous
 * Remove leftover references to ROCKSDB_LITE (#755).


### PR DESCRIPTION
Fix cross-compilation on macOS x86_64 CPUs with target CPU arm64 by manually setting CMAKE_SYSTEM_PROCESSOR to the cross-compilation target whenever CMAKE_SYSTEM_PROCESSOR doesn't match CMAKE_OSX_ARCHITECTURES after project() call. This is probably a Cmake bug that happens on macOS. (#822).

The issue happens when SpeeDB is built using the follwoing command:
`cmake -G "Unix Makefiles" -DCMAKE_SYSTEM_PROCESSOR=arm64 ..`
The build itself succeeds, but because Cmake wrongly sets CMAKE_SYSTEM_PROCESSOR to x86_64 instead of arm64 and causes crc32c_arm64.cc not to be compiled.
This in turn makes the project fails any linking with SpeeDB:
```
Undefined symbols for architecture arm64:
"crc32c_arm64(unsigned int, unsigned char const*, unsigned long)", referenced from:
speedb::crc32c::ExtendARMImpl(unsigned int, char const*, unsigned long) in libspeedb.a(crc32c.cc.o)
```