### PR TITLE
WriteController: Remove redundant setting delay reports with single db

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,16 @@
 # Speedb Change Log 
 
 ## Unreleased
+
+### New Features 
+
+### Enhancements
+
+### Bug Fixes
+
+### Miscellaneous
+
+## Incaberry 2.8.0 (31/1/2024)
 Based on RocksDB 8.6.7
 
 ### New Features 
@@ -38,7 +48,7 @@ RocksDB has a value of 10 by default and we've added the option to randomize the
 * Options: Set level_compaction_dynamic_level_bytes as false by default. This flag is not working properly with Speedb. see https://github.com/speedb-io/speedb/issues/786 for more details.
 * zlib: Update links to zlib 1.3 in CI and Makefile since the link in zlib.net is dead.
 
-## Hazlenut 2.7.0 (27/10/2023)
+## Hazelnut 2.7.0 (27/10/2023)
 Based on RocksDB 8.1.1
 
 ### New Features 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 ### Miscellaneous
+* WriteController logging: Remove redundant reports when WC is not shared between dbs
 
 ## Incaberry 2.8.0 (31/1/2024)
 Based on RocksDB 8.6.7

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1123,8 +1123,8 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
       ROCKS_LOG_WARN(
           ioptions_.logger,
           "[%s] Stalling writes because we have %d immutable memtables "
-          "(waiting for flush), max_write_buffer_number is set to %d "
-          "rate %" PRIu64,
+          "(waiting for flush), max_write_buffer_number is set to %d. "
+          "delayed write rate: %" PRIu64,
           name_.c_str(), imm()->NumNotFlushed(),
           mutable_cf_options.max_write_buffer_number,
           write_controller->delayed_write_rate());
@@ -1146,8 +1146,8 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
             1);
       }
       ROCKS_LOG_WARN(ioptions_.logger,
-                     "[%s] Stalling writes because we have %d level-0 files "
-                     "rate %" PRIu64,
+                     "[%s] Stalling writes because we have %d level-0 files. "
+                     "delayed write rate: %" PRIu64,
                      name_.c_str(), vstorage->l0_delay_trigger_count(),
                      write_controller->delayed_write_rate());
     } else if (write_stall_condition == WriteStallCondition::kDelayed &&
@@ -1175,7 +1175,7 @@ WriteStallCondition ColumnFamilyData::RecalculateWriteStallConditions(
       ROCKS_LOG_WARN(
           ioptions_.logger,
           "[%s] Stalling writes because of estimated pending compaction "
-          "bytes %" PRIu64 " rate %" PRIu64,
+          "bytes %" PRIu64 ". delayed write rate: %" PRIu64,
           name_.c_str(), vstorage->estimated_compaction_needed_bytes(),
           write_controller->delayed_write_rate());
     } else {

--- a/db/write_controller.cc
+++ b/db/write_controller.cc
@@ -149,6 +149,10 @@ void WriteController::HandleNewDelayReq(void* client_id,
 
   {
     std::lock_guard<std::mutex> logger_lock(loggers_map_mu_);
+    // The below WARN msg is intended only when the WC is shared among loggers.
+    if (loggers_to_client_ids_map_.size() == 1) {
+      return;
+    }
     for (auto& logger_and_clients : loggers_to_client_ids_map_) {
       ROCKS_LOG_WARN(logger_and_clients.first.get(),
                      "WC setting delay of %" PRIu64


### PR DESCRIPTION
The WC currently reports to the log whenever a new delay request is handled (even if its the same rate). 
These msgs are redundant in cases where the WC is only shared with 1 db and hence 1 logger since similar msgs are reported in ColumnFamilyData::RecalculateWriteStallConditions.

Currently it looks like :
```
2024/02/11-12:34:41.726676 7213 [WARN] [/write_controller.cc:153] WC setting delay of 178892456, client_id: 0x563f8a2e8f60, client rate: 178892456
2024/02/11-12:34:41.726684 7213 [WARN] [/column_family.cc:1235] [default] Stalling writes because we have 12 level-0 files rate 178892456
```
This PR removes the msg from the write_controller (the first) when there is only 1 logger to report to.