### PR TITLE
CancelAllBackgroundWork: Flush will not wait for stall conditions to clear

### DIFF
--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -550,7 +550,9 @@ void DBImpl::CancelAllBackgroundWork(bool wait) {
   if (!shutting_down_.load(std::memory_order_acquire) &&
       has_unpersisted_data_.load(std::memory_order_relaxed) &&
       !mutable_db_options_.avoid_flush_during_shutdown) {
-    s = DBImpl::FlushAllColumnFamilies(FlushOptions(), FlushReason::kShutDown);
+    auto flush_options = FlushOptions();
+    flush_options.allow_write_stall = true;
+    s = DBImpl::FlushAllColumnFamilies(flush_options, FlushReason::kShutDown);
     s.PermitUncheckedError();  //**TODO: What to do on error?
   }
 


### PR DESCRIPTION
When closing the db,  CancelAllBackgroundWork is called and a flush is initiated when there are unpersisted writes (without wal - has_unpersisted_data_ is true).
This flush currently waits for some stall conditions to clear (in WaitUntilFlushWouldNotStallWrites). 
The wait is controlled by FlushOptions.allow_write_stall and is false by default.  

Such behaviour does not seem logical since the user simply wants to close the db and they should not be forced to wait for stall conditions.

In cases such as db_bench, this leads to some obscurity by sometimes hiding the compaction debt.
This hiding effect is caused when the test ends in a stall condition and it has unpersisted data. As mentioned above, new compactions will be executed since CancelAllBackgroundWork is waiting until the flush ends which in turn waits for the stall conditions to clear.
A different test which has a lower compaction debt will close in much shorter time and the benefit of having a lower compaction debt will be overlooked

Solve this by allowing the flush to run despite the stall conditions and thus only currently running bg operations will be executed and not new ones.
