### PR TITLE
854: set the default bucket size of hashspdb to be 400k 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@
 ### New Features 
 
 ### Enhancements
+* set the default bucket size of hashspdb to be 400k for best memory use and performance (#854)
 
 ### Bug Fixes
 * LOG Consistency:Display the pinning policy options same as block cache options / metadata cache options (#804).

--- a/memtable/hash_spdb_rep.cc
+++ b/memtable/hash_spdb_rep.cc
@@ -554,7 +554,7 @@ static std::unordered_map<std::string, OptionTypeInfo> hash_spdb_factory_info =
 
 class HashSpdbRepFactory : public MemTableRepFactory {
  public:
-  explicit HashSpdbRepFactory(size_t hash_bucket_count = 1000000,
+  explicit HashSpdbRepFactory(size_t hash_bucket_count = 400000,
                               bool use_merge = true) {
     options_.hash_bucket_count = hash_bucket_count;
     options_.use_merge = use_merge;

--- a/tools/db_bench_tool.cc
+++ b/tools/db_bench_tool.cc
@@ -1910,7 +1910,7 @@ DEFINE_int64(multiread_stride, 0,
 DEFINE_bool(multiread_batched, false, "Use the new MultiGet API");
 
 DEFINE_string(memtablerep, "hash_spdb", "");
-DEFINE_int64(hash_bucket_count, 1000000, "hash bucket count");
+DEFINE_int64(hash_bucket_count, 400000, "hash bucket count");
 DEFINE_bool(use_plain_table, false,
             "if use plain table instead of block-based table format");
 DEFINE_bool(use_cuckoo_table, false, "if use cuckoo table format");


### PR DESCRIPTION
set the default bucket size of hashspdb to be 400k for best memory use and performance