### PR TITLE
WBM: Fix stall deadlock with multiple cfs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 * LOG Consistency:Display the pinning policy options same as block cache options / metadata cache options (#804).
+* WBM: fix allow_stall deadlock with multiple cfs.
 
 ### Miscellaneous
 * WriteController logging: Remove redundant reports when WC is not shared between dbs

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -1763,7 +1763,7 @@ Status DBImpl::HandleWriteBufferManagerFlush(WriteContext* write_context) {
         // and no immutable memtables for which flush has yet to finish. If
         // we triggered flush on CFs already trying to flush, we would risk
         // creating too many immutable memtables leading to write stalls.
-        auto mem_used = cfd->mem()->ApproximateMemoryUsageFast();
+        auto mem_used = cfd->mem()->ApproximateMemoryUsage();
         cfds.push_back(cfd);
         total_mem_to_free -= mem_used;
         if (total_mem_to_free <= 0) {

--- a/include/rocksdb/write_buffer_manager.h
+++ b/include/rocksdb/write_buffer_manager.h
@@ -155,7 +155,7 @@ class WriteBufferManager final {
   }
 
   int64_t memory_above_flush_trigger() {
-    return mutable_memtable_memory_usage() - buffer_size() * kMutableLimit;
+    return memory_usage() - buffer_size() * kMutableLimit;
   }
 
   // Returns the total inactive memory used by memtables.

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -54,7 +54,7 @@ WriteBufferManager::WriteBufferManager(
     const FlushInitiationOptions& flush_initiation_options,
     uint16_t start_delay_percent)
     : buffer_size_(_buffer_size),
-      mutable_limit_(buffer_size_ * 7 / 8),
+      mutable_limit_(buffer_size_ * kMutableLimit),
       memory_used_(0),
       memory_inactive_(0),
       memory_being_freed_(0U),

--- a/memtable/write_buffer_manager.cc
+++ b/memtable/write_buffer_manager.cc
@@ -112,6 +112,12 @@ void WriteBufferManager::ReserveMem(size_t mem) {
         memory_used_.fetch_add(mem, std::memory_order_relaxed);
     new_memory_used = old_memory_used + mem;
   }
+  for (auto loggers : loggers_to_client_ids_map_) {
+    ROCKS_LOG_WARN(loggers.first,
+                   "WBM (%p) ReserveMem called with:  %" PRIu64
+                   " , memory_used: %" PRIu64,
+                   this, mem, new_memory_used);
+  }
   if (is_enabled) {
     UpdateUsageState(new_memory_used, static_cast<int64_t>(mem), buffer_size());
     // Checking outside the locks is not reliable, but avoids locking
@@ -177,7 +183,12 @@ void WriteBufferManager::FreeMem(size_t mem) {
     assert(old_memory_used >= mem);
     new_memory_used = old_memory_used - mem;
   }
-
+  for (auto loggers : loggers_to_client_ids_map_) {
+    ROCKS_LOG_WARN(loggers.first,
+                   "WBM (%p) FreeMem called with: %" PRIu64
+                   ", memory_used: %" PRIu64,
+                   this, mem, new_memory_used);
+  }
   if (is_enabled) {
     [[maybe_unused]] const auto curr_memory_inactive =
         memory_inactive_.fetch_sub(mem, std::memory_order_relaxed);


### PR DESCRIPTION
With a setting of multiple cfs and WriteBufferManager with allow_stall, the DB can enter a deadlock when the WBM initiates a stall. This happens since only the oldest cf is picked for flush when HandleWriteBufferManagerFlush is called to flush the data and prevent the stall. When using multiple CFs, this does not ensure the FreeMem will evict enough memory to prevent a stall and no other flush is scheduled.

To fix this, add cfs to the flush queue so that we'll be below the mutable_limit_.

closes #857